### PR TITLE
Support the injection of RxJava 1 and 2 Vertx instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,30 +56,13 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-docgen</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web-client</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java2</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -96,6 +79,19 @@
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <version>${junit-platform-launcher.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-docgen</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,20 +51,12 @@
   </dependencyManagement>
 
   <dependencies>
+
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit-jupiter.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-jupiter.version}</version>
-    </dependency>
+
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
@@ -77,6 +69,35 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java2</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit-jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${junit-platform-launcher.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -92,11 +113,6 @@
       <optional>true</optional>
     </dependency>
 
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>${junit-platform-launcher.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <stack.version>3.6.0-SNAPSHOT</stack.version>
     <junit-jupiter.version>5.1.0</junit-jupiter.version>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-    <junit-platform-surefire-provider.version>1.0.2</junit-platform-surefire-provider.version>
+    <junit-platform-surefire-provider.version>1.1.0</junit-platform-surefire-provider.version>
     <assertj-core.version>3.9.0</assertj-core.version>
     <apiguardian-api.version>1.0.0</apiguardian-api.version>
     <junit-platform-launcher.version>1.1.0</junit-platform-launcher.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,23 +69,27 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj-core.version}</version>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apiguardian</groupId>
       <artifactId>apiguardian-api</artifactId>
       <version>${apiguardian-api.version}</version>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -166,7 +166,7 @@ This is a problem of JUnit 5 rather than this module. In case of doubt you may a
 
 ==== Support for RxJava 1 and 2 Vertx instances
 
-Reactive extension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
+Reactive eXtension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
 They provide shims / wrappers around the Vert.x core APIs, like {@link io.vertx.rxjava.core.Vertx} (RxJava 1) and {@link io.vertx.reactivex.core.Vertx} (RxJava 2).
 
 Instances of these _"Rx-ified"_ `Vertx` classes can be injected in test and lifecycle methods, as in:

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -163,3 +163,15 @@ As an example, it is possible to define 3 `@BeforeEach` methods on the same test
 Because of asynchronous operations it is possible that the effects of these methods happen concurrently rather than sequentially, which may lead to inconsistent states.
 
 This is a problem of JUnit 5 rather than this module. In case of doubt you may always wonder why a single method can't be better than many.
+
+==== Support for RxJava 1 and 2 Vertx instances
+
+Reactive extension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
+They provide shims / wrappers around the Vert.x core APIs, like {@link io.vertx.rxjava.core.Vertx} (RxJava 1) and {@link io.vertx.reactivex.core.Vertx} (RxJava 2).
+
+Instances of these _"Rx-ified"_ `Vertx` classes can be injected in test and lifecycle methods, as in:
+
+[source,java]
+----
+{@link examples.RxJava2Test}
+----

--- a/src/main/asciidoc/output/index.adoc
+++ b/src/main/asciidoc/output/index.adoc
@@ -304,3 +304,59 @@ As an example, it is possible to define 3 `@BeforeEach` methods on the same test
 Because of asynchronous operations it is possible that the effects of these methods happen concurrently rather than sequentially, which may lead to inconsistent states.
 
 This is a problem of JUnit 5 rather than this module. In case of doubt you may always wonder why a single method can't be better than many.
+
+==== Support for RxJava 1 and 2 Vertx instances
+
+Reactive extension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
+They provide shims / wrappers around the Vert.x core APIs, like `link:../../apidocs/io/vertx/rxjava/core/Vertx.html[Vertx]` (RxJava 1) and `link:../../apidocs/io/vertx/reactivex/core/Vertx.html[Vertx]` (RxJava 2).
+
+Instances of these _"Rx-ified"_ `Vertx` classes can be injected in test and lifecycle methods, as in:
+
+[source,java]
+----
+@DisplayName("👀 A RxJava 2 + Vert.x test")
+@ExtendWith(VertxExtension.class)
+class RxJava2Test {
+
+  @BeforeEach
+  void prepare(Vertx vertx, VertxTestContext testContext) {
+    RxHelper.deployVerticle(vertx, new ServerVerticle())
+      .subscribe(id -> testContext.completeNow(), testContext::failNow);
+  }
+
+  @Test
+  @DisplayName("🚀 Start a server and perform requests")
+  void server_test(Vertx vertx, VertxTestContext testContext) {
+    Checkpoint checkpoints = testContext.strictCheckpoint(10);
+
+    HttpRequest<String> request = WebClient
+      .create(vertx)
+      .get(8080, "localhost", "/")
+      .as(BodyCodec.string());
+
+    request
+      .rxSend()
+      .repeat(10)
+      .subscribe(
+        response -> testContext.verify(() -> {
+          assertThat(response.body()).isEqualTo("Ok");
+          checkpoints.flag();
+        }),
+        testContext::failNow);
+  }
+
+  class ServerVerticle extends AbstractVerticle {
+
+    @Override
+    public void start(Future<Void> startFuture) throws Exception {
+      vertx.createHttpServer()
+        .requestHandler(req -> {
+          System.out.println(req.method() + " " + req.uri() + " from " + req.remoteAddress().host());
+          req.response().end("Ok");
+        })
+        .rxListen(8080)
+        .subscribe(server -> startFuture.complete(), startFuture::fail);
+    }
+  }
+}
+----

--- a/src/main/asciidoc/output/index.adoc
+++ b/src/main/asciidoc/output/index.adoc
@@ -307,7 +307,7 @@ This is a problem of JUnit 5 rather than this module. In case of doubt you may a
 
 ==== Support for RxJava 1 and 2 Vertx instances
 
-Reactive extension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
+Reactive eXtension support in Vert.x is being provided by the `vertx-rx-java` and `vertx-rx-java2` modules.
 They provide shims / wrappers around the Vert.x core APIs, like `link:../../apidocs/io/vertx/rxjava/core/Vertx.html[Vertx]` (RxJava 1) and `link:../../apidocs/io/vertx/reactivex/core/Vertx.html[Vertx]` (RxJava 2).
 
 Instances of these _"Rx-ified"_ `Vertx` classes can be injected in test and lifecycle methods, as in:

--- a/src/main/java/examples/RxJava2Test.java
+++ b/src/main/java/examples/RxJava2Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package examples;
+
+import io.vertx.core.Future;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.RxHelper;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import io.vertx.reactivex.ext.web.codec.BodyCodec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("👀 A RxJava 2 + Vert.x test")
+@ExtendWith(VertxExtension.class)
+class RxJava2Test {
+
+  @BeforeEach
+  void prepare(Vertx vertx, VertxTestContext testContext) {
+    RxHelper.deployVerticle(vertx, new ServerVerticle())
+      .subscribe(id -> testContext.completeNow(), testContext::failNow);
+  }
+
+  @Test
+  @DisplayName("🚀 Start a server and perform requests")
+  void server_test(Vertx vertx, VertxTestContext testContext) {
+    Checkpoint checkpoints = testContext.strictCheckpoint(10);
+
+    HttpRequest<String> request = WebClient
+      .create(vertx)
+      .get(8080, "localhost", "/")
+      .as(BodyCodec.string());
+
+    request
+      .rxSend()
+      .repeat(10)
+      .subscribe(
+        response -> testContext.verify(() -> {
+          assertThat(response.body()).isEqualTo("Ok");
+          checkpoints.flag();
+        }),
+        testContext::failNow);
+  }
+
+  class ServerVerticle extends AbstractVerticle {
+
+    @Override
+    public void start(Future<Void> startFuture) throws Exception {
+      vertx.createHttpServer()
+        .requestHandler(req -> {
+          System.out.println(req.method() + " " + req.uri() + " from " + req.remoteAddress().host());
+          req.response().end("Ok");
+        })
+        .rxListen(8080)
+        .subscribe(server -> startFuture.complete(), startFuture::fail);
+    }
+  }
+}

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -46,7 +46,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
  * <li>{@link Vertx}</li>
  * <li>{@link VertxTestContext}</li>
  * <li>{@link io.vertx.rxjava.core.Vertx}</li>
- * <li>{@link io.vertx.rxjava.core.Vertx}</li>
+ * <li>{@link io.vertx.reactivex.core.Vertx}</li>
  * </ul>
  *
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -61,10 +62,18 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
     BEFORE_ALL, BEFORE_EACH, TEST
   }
 
+  private static final HashSet<Class> INJECTABLE_TYPES = new HashSet<Class>() {
+    {
+      add(Vertx.class);
+      add(VertxTestContext.class);
+      add(io.vertx.rxjava.core.Vertx.class);
+      add(io.vertx.reactivex.core.Vertx.class);
+    }
+  };
+
   @Override
   public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-    Class<?> type = parameterType(parameterContext);
-    return type == VertxTestContext.class || type == Vertx.class;
+    return INJECTABLE_TYPES.contains(parameterType(parameterContext));
   }
 
   private Class<?> parameterType(ParameterContext parameterContext) {
@@ -76,6 +85,12 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
     Class<?> type = parameterType(parameterContext);
     if (type == Vertx.class) {
       return getOrCreateVertx(parameterContext, extensionContext);
+    }
+    if (type == io.vertx.rxjava.core.Vertx.class) {
+      throw new UnsupportedOperationException("RxJava 1 not implemented yet");
+    }
+    if (type == io.vertx.reactivex.core.Vertx.class) {
+      throw new UnsupportedOperationException("RxJava 2 not implemented yet");
     }
     if (type == VertxTestContext.class) {
       return newTestContext(extensionContext);

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -198,6 +198,7 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
     };
   }
 
+  @FunctionalInterface
   private interface ThrowingConsumer {
     void accept(Object obj) throws Exception;
   }

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -39,8 +39,15 @@ import java.util.function.Function;
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
 /**
- * JUnit 5 Vert.x extension that allows the injection of {@link Vertx} and {@link VertxTestContext} parameters as well as
- * an automatic lifecycle on the {@link VertxTestContext} instance.
+ * JUnit 5 Vert.x extension that allows parameter injection as well as an automatic lifecycle on the {@link VertxTestContext} instance.
+ * <p>
+ * The following types can be injected:
+ * <ul>
+ *     <li>{@link Vertx}</li>
+ *     <li>{@link VertxTestContext}</li>
+ *     <li>{@link io.vertx.rxjava.core.Vertx}</li>
+ *     <li>{@link io.vertx.rxjava.core.Vertx}</li>
+ * </ul>
  *
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */

--- a/src/test/java/io/vertx/junit5/RxJava1Test.java
+++ b/src/test/java/io/vertx/junit5/RxJava1Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import io.vertx.rxjava.core.Vertx;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@Disabled
+@DisplayName("Test the RxJava 1 support")
+class RxJava1Test {
+
+  @Test
+  @DisplayName("Check the injection of a /io.vertx.rxjava.core.Vertx/ instance")
+  void check_injection(Vertx vertx, VertxTestContext testContext) {
+
+  }
+}

--- a/src/test/java/io/vertx/junit5/RxJava2Test.java
+++ b/src/test/java/io/vertx/junit5/RxJava2Test.java
@@ -16,9 +16,9 @@
 
 package io.vertx.junit5;
 
-import io.vertx.rxjava.core.AbstractVerticle;
-import io.vertx.rxjava.core.RxHelper;
-import io.vertx.rxjava.core.Vertx;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.RxHelper;
+import io.vertx.reactivex.core.Vertx;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(VertxExtension.class)
-@DisplayName("Test the RxJava 1 support")
-class RxJava1Test {
+@DisplayName("Test the RxJava 2 support")
+class RxJava2Test {
 
   @Test
-  @DisplayName("Check the injection of a /io.vertx.rxjava.core.Vertx/ instance")
+  @DisplayName("Check the injection of a /io.vertx.reactivex.core.Vertx/ instance")
   void check_injection(Vertx vertx, VertxTestContext testContext) {
     testContext.verify(() -> {
       assertThat(vertx).isNotNull();
@@ -43,7 +43,6 @@ class RxJava1Test {
   void check_deployment_and_message_send(Vertx vertx, VertxTestContext testContext) {
     RxHelper
       .deployVerticle(vertx, new RxVerticle())
-      .toSingle()
       .flatMap(id -> vertx.eventBus().rxSend("check", "Ok?"))
       .subscribe(
         message -> testContext.verify(() -> {


### PR DESCRIPTION
This allows injecting instances of both `io.vertx.rxjava.core.Vertx` and `io.vertx.rxjava.core.Vertx` in test and lifecycle methods.

Along the way I refactored the code to make it nice for future (scoped) injectables.

Fixes #33 