### PR TITLE
Use store close callback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
 
   <properties>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
-    <junit-jupiter.version>5.0.3</junit-jupiter.version>
+    <junit-jupiter.version>5.1.0</junit-jupiter.version>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
     <junit-platform-surefire-provider.version>1.0.2</junit-platform-surefire-provider.version>
     <assertj-core.version>3.9.0</assertj-core.version>
     <apiguardian-api.version>1.0.0</apiguardian-api.version>
-    <junit-platform-launcher.version>1.0.3</junit-platform-launcher.version>
+    <junit-platform-launcher.version>1.1.0</junit-platform-launcher.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This is a proof-of-concept commit that shows how the extension context store callback can be used to close a resource. Needs to be applied to the other two stored vertices as well and a polishing pass that removes no longer need cleanup code.