### PR TITLE
Provide a completion helper

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -41,7 +41,7 @@ Here is a very basic usage:
 ----
 {@link examples.Examples.BTest}
 ----
-<1> {@link io.vertx.junit5.VertxTestContext#succeeding} returns an asynchronous result handler that is expected to succeed, and {@link io.vertx.junit5.VertxTestContext#completeNow} makes the test pass.
+<1> {@link io.vertx.junit5.VertxTestContext#completing} returns an asynchronous result handler that is expected to succeed and then make the test context pass.
 <2> {@link io.vertx.junit5.VertxTestContext#awaitCompletion} has the semantics of a `java.util.concurrent.CountDownLatch`, and returns `false` if the waiting delay expired before the test passed.
 <3> If the context captures a (potentially asynchronous) error, then after completion we must throw the failure exception to make the test fail.
 
@@ -60,11 +60,12 @@ To make assertions in asynchronous code and make sure that {@link io.vertx.junit
 The useful methods in {@link io.vertx.junit5.VertxTestContext} are the following:
 
 * {@link io.vertx.junit5.VertxTestContext#completeNow} and {@link io.vertx.junit5.VertxTestContext#failNow} to notify of a success or failure
+* {@link io.vertx.junit5.VertxTestContext#completing} to provide `Handler<AsyncResult<T>>` handlers that expect a success and then completes the test context
 * {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success, and optionally pass the result to another callback
 * {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure, and optionally pass the exception to another callback
 * {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the `java.lang.Runnable` is considered as a test failure.
 
-WARNING: Calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
+WARNING: Unlike `completing()`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
 To make a test pass you still need to call `completeNow`, or use checkpoints as explained below.
 
 == Checkpoint when there are multiple success conditions

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -62,7 +62,7 @@ public class Examples {
       Vertx vertx = Vertx.vertx();
       vertx.createHttpServer()
         .requestHandler(req -> req.response().end())
-        .listen(16969, testContext.succeeding(ar -> testContext.completeNow())); // <1>
+        .listen(16969, testContext.completing()); // <1>
 
       assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS)).isTrue(); // <2>
       if (testContext.failed()) {  // <3>
@@ -157,7 +157,7 @@ public class Examples {
       // Deploy the verticle and execute the test methods when the verticle is successfully deployed
       @BeforeEach
       void deploy_verticle(Vertx vertx, VertxTestContext testContext) {
-        vertx.deployVerticle(new HttpServerVerticle(), testContext.succeeding());
+        vertx.deployVerticle(new HttpServerVerticle(), testContext.completing());
       }
 
       // Repeat this test 3 times

--- a/src/main/java/examples/LifecycleExampleTest.java
+++ b/src/main/java/examples/LifecycleExampleTest.java
@@ -37,7 +37,7 @@ class LifecycleExampleTest {
   @BeforeEach
   @DisplayName("Deploy a verticle")
   void prepare(Vertx vertx, VertxTestContext testContext) {
-    vertx.deployVerticle(new SomeVerticle(), testContext.succeeding(id -> testContext.completeNow()));
+    vertx.deployVerticle(new SomeVerticle(), testContext.completing());
   }
 
   @Test

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -203,6 +203,22 @@ public final class VertxTestContext {
     };
   }
 
+  /**
+   * Create an asynchronous result handler that expects a success to then complete the test context.
+   *
+   * @param <T> the asynchronous result type.
+   * @return the handler.
+   */
+  public <T> Handler<AsyncResult<T>> completing() {
+    return ar -> {
+      if (ar.succeeded()) {
+        completeNow();
+      } else {
+        failNow(ar.cause());
+      }
+    };
+  }
+
   // ........................................................................................... //
 
   /**

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -223,4 +223,24 @@ class VertxTestContextTest {
     assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
     assertThat(context.failed()).isTrue();
   }
+
+  @Test
+  @DisplayName("Pass a success to a completing() async handler")
+  void check_completing_success() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.completing().handle(Future.succeededFuture());
+    assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.completed()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Pass a failure to a completing() async handler")
+  void check_completing_failure() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.completing().handle(Future.failedFuture(new RuntimeException("Boo!")));
+    assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.completed()).isFalse();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure()).hasMessage("Boo!");
+  }
 }


### PR DESCRIPTION
This reduces boilerplate and hopefuly avoids incorrect usage of succeeding() handlers.

Fixes #44