### PR TITLE
Add suggestion to timeout exception message

### DIFF
--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -236,7 +236,9 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
             }
           }
         } else {
-          throw new TimeoutException("The test execution timed out");
+          throw new TimeoutException("The test execution timed out. Make sure your asynchronous code "
+            + "includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() "
+            + "or Checkpoint#flag()");
         }
       }
     }


### PR DESCRIPTION
## Overview
Add suggestion to timeout exception message to simplify debugging.
Any asynchronous callback must use either VertxTestContext#completeNow()
or Checkpoint#flag() to indicate that it has finished.