### PR TITLE
Rename checkpoint() to laxCheckpoint(), rename strictCheckpoint() to checkpoint()

### DIFF
--- a/src/main/java/examples/RxJava2Test.java
+++ b/src/main/java/examples/RxJava2Test.java
@@ -46,7 +46,7 @@ class RxJava2Test {
   @Test
   @DisplayName("🚀 Start a server and perform requests")
   void server_test(Vertx vertx, VertxTestContext testContext) {
-    Checkpoint checkpoints = testContext.strictCheckpoint(10);
+    Checkpoint checkpoints = testContext.checkpoint(10);
 
     HttpRequest<String> request = WebClient
       .create(vertx)

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -100,8 +100,8 @@ public final class VertxTestContext {
    *
    * @return a checkpoint that requires 1 pass.
    */
-  public Checkpoint checkpoint() {
-    return checkpoint(1);
+  public Checkpoint laxCheckpoint() {
+    return laxCheckpoint(1);
   }
 
   /**
@@ -110,7 +110,7 @@ public final class VertxTestContext {
    * @param requiredNumberOfPasses the required number of passes to validate the checkpoint.
    * @return a checkpoint that requires several passes.
    */
-  public synchronized Checkpoint checkpoint(int requiredNumberOfPasses) {
+  public synchronized Checkpoint laxCheckpoint(int requiredNumberOfPasses) {
     CountingCheckpoint checkpoint = CountingCheckpoint.laxCountingCheckpoint(this::checkpointSatisfied, requiredNumberOfPasses);
     checkpoints.add(checkpoint);
     return checkpoint;
@@ -121,8 +121,8 @@ public final class VertxTestContext {
    *
    * @return a checkpoint that requires 1 pass, and makes the context fail if it is called more than once.
    */
-  public Checkpoint strictCheckpoint() {
-    return strictCheckpoint(1);
+  public Checkpoint checkpoint() {
+    return checkpoint(1);
   }
 
   /**
@@ -131,7 +131,7 @@ public final class VertxTestContext {
    * @param requiredNumberOfPasses the required number of passes to validate the checkpoint.
    * @return a checkpoint that requires several passes, but no more or it fails the context.
    */
-  public synchronized Checkpoint strictCheckpoint(int requiredNumberOfPasses) {
+  public synchronized Checkpoint checkpoint(int requiredNumberOfPasses) {
     CountingCheckpoint checkpoint = CountingCheckpoint.strictCountingCheckpoint(this::checkpointSatisfied, this::failNow, requiredNumberOfPasses);
     checkpoints.add(checkpoint);
     return checkpoint;


### PR DESCRIPTION
The vast majority of asynchronous implementations require a strict checkpoint.
Therefore the default checkpoint() function should return a strict checkpoint.

This is an API change that may break existing code. However, https://vertx.io/docs/vertx-junit5/java/ says: "Warning | This module has Tech Preview status, this means the API can change between versions."