### PR TITLE
Interface for verify() that accepts checked exceptions

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -61,7 +61,7 @@ The useful methods in {@link io.vertx.junit5.VertxTestContext} are the following
 * {@link io.vertx.junit5.VertxTestContext#completing} to provide `Handler<AsyncResult<T>>` handlers that expect a success and then completes the test context
 * {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success, and optionally pass the result to another callback
 * {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure, and optionally pass the exception to another callback
-* {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the `java.lang.Runnable` is considered as a test failure.
+* {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the code block is considered as a test failure.
 
 WARNING: Unlike `completing()`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
 To make a test pass you still need to call `completeNow`, or use checkpoints as explained below.

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -32,6 +32,19 @@ import java.util.concurrent.TimeUnit;
  */
 public final class VertxTestContext {
 
+  /**
+   * Interface for an executable block of assertion code.
+   *
+   * @see #verify(ExecutionBlock)
+   */
+  @FunctionalInterface
+  public interface ExecutionBlock {
+
+    void apply() throws Throwable;
+  }
+
+  // ........................................................................................... //
+
   private Throwable throwableReference = null;
   private final CountDownLatch releaseLatch = new CountDownLatch(1);
   private final HashSet<Checkpoint> checkpoints = new HashSet<>();
@@ -223,7 +236,7 @@ public final class VertxTestContext {
   // ........................................................................................... //
 
   /**
-   * This method allows you to check if a future is completed. 
+   * This method allows you to check if a future is completed.
    * It internally creates a checkpoint.
    * You can use it in a chain of `Future`.
    *
@@ -278,10 +291,10 @@ public final class VertxTestContext {
    * @param block a block of code to execute.
    * @return this context.
    */
-  public VertxTestContext verify(Runnable block) {
+  public VertxTestContext verify(ExecutionBlock block) {
     Objects.requireNonNull(block, "The block cannot be null");
     try {
-      block.run();
+      block.apply();
     } catch (Throwable t) {
       failNow(t);
     }

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -18,18 +18,14 @@ package io.vertx.junit5;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
@@ -369,5 +365,18 @@ class VertxTestContextTest {
     assertThat(context.causeOfFailure())
       .isInstanceOf(AssertionError.class)
       .hasMessage("Future completed with value: blabla");
+  }
+
+  @Test
+  @DisplayName("Call verify() with a block that throws an exception")
+  void check_verify_with_exception() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.verify(() -> {
+      throw new RuntimeException("!");
+    });
+    assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.causeOfFailure())
+      .hasMessage("!")
+      .isInstanceOf(RuntimeException.class);
   }
 }


### PR DESCRIPTION
Runnable does not support checked exceptions, so allowing exceptions
here simplifies assertion code.

This is a breaking change but since most usages of verify() are with
lambda and possibly method references, this should be vastly transparent.

Suggested by Thomas Segismont.