### PR TITLE
Publish Vert.x object to global scope

### DIFF
--- a/src/test/java/io/vertx/junit5/OtherExtension.java
+++ b/src/test/java/io/vertx/junit5/OtherExtension.java
@@ -1,0 +1,25 @@
+package io.vertx.junit5;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class OtherExtension implements ParameterResolver {
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    Class<?> type = parameterContext.getParameter().getType();
+    return type.equals(OtherVertx.class);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    Class<?> type = parameterContext.getParameter().getType();
+    ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.create(OtherExtension.class, extensionContext));
+    if (OtherVertx.class.equals(type))
+      return store.getOrComputeIfAbsent("otherVertx", k -> new OtherVertx(VertxExtension.retrieveVertx(parameterContext.getDeclaringExecutable(), extensionContext)));
+    throw new IllegalStateException("Looks like the ParameterResolver needs a fix...");
+  }
+}

--- a/src/test/java/io/vertx/junit5/OtherExtension.java
+++ b/src/test/java/io/vertx/junit5/OtherExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.junit5;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/junit5/OtherExtensionIntegrationTest.java
+++ b/src/test/java/io/vertx/junit5/OtherExtensionIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.junit5;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/junit5/OtherExtensionIntegrationTest.java
+++ b/src/test/java/io/vertx/junit5/OtherExtensionIntegrationTest.java
@@ -1,0 +1,28 @@
+package io.vertx.junit5;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(VertxExtension.class)
+@ExtendWith(OtherExtension.class)
+public class OtherExtensionIntegrationTest {
+
+  @Test
+  public void testParam(Vertx vertx, OtherVertx otherVertx) {
+    assertEquals(vertx, otherVertx.vertx);
+  }
+
+  @Test
+  public void testInvertedParam(OtherVertx otherVertx, Vertx vertx) {
+    assertEquals(vertx, otherVertx.vertx);
+  }
+
+  @Test
+  public void testOnlyOtherVertx(OtherVertx otherVertx) {
+    assertNotNull(otherVertx.vertx);
+  }
+}

--- a/src/test/java/io/vertx/junit5/OtherVertx.java
+++ b/src/test/java/io/vertx/junit5/OtherVertx.java
@@ -1,0 +1,12 @@
+package io.vertx.junit5;
+
+import io.vertx.core.Vertx;
+
+public class OtherVertx {
+
+  public final Vertx vertx;
+
+  public OtherVertx(Vertx vertx) {
+    this.vertx = vertx;
+  }
+}

--- a/src/test/java/io/vertx/junit5/OtherVertx.java
+++ b/src/test/java/io/vertx/junit5/OtherVertx.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.junit5;
 
 import io.vertx.core.Vertx;


### PR DESCRIPTION
This should allow other extensions to retrieve Vert.x object. Closes #59

Signed-off-by: slinkydeveloper <francescoguard@gmail.com>