### PR TITLE
Better checkpoint diagnostics

### DIFF
--- a/vertx-junit5/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/vertx-junit5/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -61,7 +61,7 @@ final class CountingCheckpoint implements Checkpoint {
         return stackTrace[i + 1];
       }
     }
-    throw new IllegalStateException();
+    return stackTrace[1]; // This can only happen from direct usage of CountingCheckpoint in tests, so the value is irrelevant
   }
 
   @Override

--- a/vertx-junit5/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/vertx-junit5/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -73,4 +73,8 @@ final class CountingCheckpoint implements Checkpoint {
       overuseTrigger.accept(new IllegalStateException("Strict checkpoint flagged too many times"));
     }
   }
+
+  public boolean satisfied() {
+    return this.satisfied;
+  }
 }

--- a/vertx-junit5/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/vertx-junit5/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
@@ -227,9 +228,15 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
             }
           }
         } else {
-          throw new TimeoutException("The test execution timed out. Make sure your asynchronous code "
+          String message = "The test execution timed out. Make sure your asynchronous code "
             + "includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() "
-            + "or Checkpoint#flag()");
+            + "or Checkpoint#flag()";
+          String unsatisfiedCheckpointsDiagnosis = context.unsatisfiedCheckpointCallSites()
+            .stream()
+            .map(element -> "-> checkpoint in file " + element.getFileName() + " line " + element.getLineNumber())
+            .collect(Collectors.joining("\n"));
+          message = message + "\n\nUnsatisfied checkpoints diagnostics:\n" + unsatisfiedCheckpointsDiagnosis;
+          throw new TimeoutException(message);
         }
       }
     }

--- a/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -22,8 +22,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -82,16 +82,16 @@ public final class VertxTestContext {
   }
 
   /**
-   * Gives the call sites of all unsatisifed checkpoints.
+   * Gives the call sites of all unsatisfied checkpoints.
    *
-   * @return a list of {@link StackTraceElement} references pointing to the unsatisfied checkpoint call sites.
+   * @return a set of {@link StackTraceElement} references pointing to the unsatisfied checkpoint call sites.
    */
-  public List<StackTraceElement> unsatisfiedCheckpointCallSites() {
+  public Set<StackTraceElement> unsatisfiedCheckpointCallSites() {
     return checkpoints
       .stream()
       .filter(checkpoint -> !checkpoint.satisfied())
       .map(CountingCheckpoint::creationCallSite)
-      .collect(Collectors.toList());
+      .collect(Collectors.toSet());
   }
 
   // ........................................................................................... //

--- a/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -22,9 +22,11 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * A test context to wait on the outcomes of asynchronous operations.
@@ -48,7 +50,7 @@ public final class VertxTestContext {
 
   private Throwable throwableReference = null;
   private final CountDownLatch releaseLatch = new CountDownLatch(1);
-  private final HashSet<Checkpoint> checkpoints = new HashSet<>();
+  private final HashSet<CountingCheckpoint> checkpoints = new HashSet<>();
 
   // ........................................................................................... //
 
@@ -77,6 +79,19 @@ public final class VertxTestContext {
    */
   public synchronized boolean completed() {
     return !failed() && releaseLatch.getCount() == 0;
+  }
+
+  /**
+   * Gives the call sites of all unsatisifed checkpoints.
+   *
+   * @return a list of {@link StackTraceElement} references pointing to the unsatisfied checkpoint call sites.
+   */
+  public List<StackTraceElement> unsatisfiedCheckpointCallSites() {
+    return checkpoints
+      .stream()
+      .filter(checkpoint -> !checkpoint.satisfied())
+      .map(CountingCheckpoint::creationCallSite)
+      .collect(Collectors.toList());
   }
 
   // ........................................................................................... //

--- a/vertx-junit5/src/test/java/io/vertx/junit5/CountingCheckpointTest.java
+++ b/vertx-junit5/src/test/java/io/vertx/junit5/CountingCheckpointTest.java
@@ -46,14 +46,17 @@ class CountingCheckpointTest {
     checkpoint.flag();
     assertThat(success).isFalse();
     assertThat(witness).hasValue(null);
+    assertThat(checkpoint.satisfied()).isFalse();
 
     checkpoint.flag();
     assertThat(success).isFalse();
     assertThat(witness).hasValue(null);
+    assertThat(checkpoint.satisfied()).isFalse();
 
     checkpoint.flag();
     assertThat(success).isTrue();
     assertThat(witness).hasValue(checkpoint);
+    assertThat(checkpoint.satisfied()).isTrue();
   }
 
   private static final Consumer<Checkpoint> NOOP = c -> {
@@ -93,12 +96,16 @@ class CountingCheckpointTest {
     AtomicReference<Throwable> box = new AtomicReference<>();
     CountingCheckpoint checkpoint = CountingCheckpoint.strictCountingCheckpoint(NOOP, box::set, 1);
 
+    assertThat(checkpoint.satisfied()).isFalse();
     checkpoint.flag();
     assertThat(box).hasValue(null);
+    assertThat(checkpoint.satisfied()).isTrue();
+
     checkpoint.flag();
     assertThat(box.get())
       .isNotNull()
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Strict checkpoint flagged too many times");
+    assertThat(checkpoint.satisfied()).isTrue();
   }
 }

--- a/vertx-junit5/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/vertx-junit5/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -379,4 +379,25 @@ class VertxTestContextTest {
       .hasMessage("!")
       .isInstanceOf(RuntimeException.class);
   }
+
+  @Test
+  @DisplayName("Check that unsatisfied call sites are properly identified")
+  void check_unsatisifed_checkpoint_callsites() {
+    VertxTestContext context = new VertxTestContext();
+    Checkpoint a = context.checkpoint();
+    Checkpoint b = context.checkpoint(2);
+
+    assertThat(context.unsatisfiedCheckpointCallSites()).hasSize(2);
+
+    a.flag();
+    b.flag();
+    assertThat(context.unsatisfiedCheckpointCallSites()).hasSize(1);
+
+    StackTraceElement element = context.unsatisfiedCheckpointCallSites().get(0);
+    assertThat(element.getClassName()).isEqualTo(VertxTestContextTest.class.getName());
+    assertThat(element.getMethodName()).isEqualTo("check_unsatisifed_checkpoint_callsites");
+
+    b.flag();
+    assertThat(context.unsatisfiedCheckpointCallSites()).isEmpty();
+  }
 }

--- a/vertx-junit5/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/vertx-junit5/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -393,7 +393,7 @@ class VertxTestContextTest {
     b.flag();
     assertThat(context.unsatisfiedCheckpointCallSites()).hasSize(1);
 
-    StackTraceElement element = context.unsatisfiedCheckpointCallSites().get(0);
+    StackTraceElement element = context.unsatisfiedCheckpointCallSites().iterator().next();
     assertThat(element.getClassName()).isEqualTo(VertxTestContextTest.class.getName());
     assertThat(element.getMethodName()).isEqualTo("check_unsatisifed_checkpoint_callsites");
 


### PR DESCRIPTION
Provide a diagnostic of unsatisfied checkpoints call sites

This inspects the call stack when a checkpoint is being created to find the most likely call site in user code.

Fixes #67