### PR TITLE
Fix missing onFailure, unit test examples.*

### DIFF
--- a/src/test/java/examples/ExamplesTest.java
+++ b/src/test/java/examples/ExamplesTest.java
@@ -1,0 +1,13 @@
+package examples;
+
+import org.junit.jupiter.api.Nested;
+
+class ExamplesTest {
+  @Nested
+  class ExamplesNested extends Examples {
+  }
+
+  @Nested
+  class LifecycleExampleTestNested extends LifecycleExampleTest {
+  }
+}


### PR DESCRIPTION
`.onSuccess(` is used without accompanying `.onFailure(` several times
resulting in missing error reporting in case of failure.
To provide the reader with complete examples the problem is fixed
by converting `.onSuccess(` to `.onComplete(testContext.succeeding(`.

For consistency the one example where both `.onSuccess(` and
`.onFailure(` exist is also converted.

The missing `responsesReceived.flag()` is added to the checkpointing
example to make it succeed.

To catch any future regressions the classes in examples directory
have been added to unit testing.

The comment in ETest is split into two lines to prevent ugly line
wrapping by browsers with big font size.

Signed-off-by: Julian Ladisch <eclipse.org-rtn@ladisch.de>