### PR TITLE
Deprecate succeeding() and failing(), add failingThenComplete()

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -39,7 +39,7 @@ Here is a very basic usage:
 ----
 {@link examples.Examples.BTest}
 ----
-<1> {@link io.vertx.junit5.VertxTestContext#completing} returns an asynchronous result handler that is expected to succeed and then make the test context pass.
+<1> {@link io.vertx.junit5.VertxTestContext#succeedingThenComplete} returns an asynchronous result handler that is expected to succeed and then make the test context pass.
 <2> {@link io.vertx.junit5.VertxTestContext#awaitCompletion} has the semantics of a `java.util.concurrent.CountDownLatch`, and returns `false` if the waiting delay expired before the test passed.
 <3> If the context captures a (potentially asynchronous) error, then after completion we must throw the failure exception to make the test fail.
 
@@ -58,12 +58,13 @@ To make assertions in asynchronous code and make sure that {@link io.vertx.junit
 The useful methods in {@link io.vertx.junit5.VertxTestContext} are the following:
 
 * {@link io.vertx.junit5.VertxTestContext#completeNow} and {@link io.vertx.junit5.VertxTestContext#failNow} to notify of a success or failure
-* {@link io.vertx.junit5.VertxTestContext#completing} to provide `Handler<AsyncResult<T>>` handlers that expect a success and then completes the test context
-* {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success, and optionally pass the result to another callback, any exception thrown from the callback is considered as a test failure
-* {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure, and optionally pass the exception to another callback, any exception thrown from the callback is considered as a test failure
+* {@link io.vertx.junit5.VertxTestContext#succeedingThenComplete} to provide `Handler<AsyncResult<T>>` handlers that expect a success and then completes the test context
+* {@link io.vertx.junit5.VertxTestContext#failingThenComplete} to provide `Handler<AsyncResult<T>>` handlers that expect a failure and then completes the test context
+* {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success and pass the result to another callback, any exception thrown from the callback is considered as a test failure
+* {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure and pass the exception to another callback, any exception thrown from the callback is considered as a test failure
 * {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the code block is considered as a test failure.
 
-WARNING: Unlike `completing()`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
+WARNING: Unlike `succeedingThenComplete` and `failingThenComplete`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
 To make a test pass you still need to call `completeNow`, or use checkpoints as explained below.
 
 == Checkpoint when there are multiple success conditions

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -72,7 +72,7 @@ public class Examples {
 
       vertx.createHttpServer()
         .requestHandler(req -> req.response().end())
-        .listen(16969, testContext.completing()); // <1>
+        .listen(16969, testContext.succeedingThenComplete()); // <1>
 
       assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS)).isTrue(); // <2>
       if (testContext.failed()) {  // <3>
@@ -93,7 +93,7 @@ public class Examples {
   void startPlopServer(Vertx vertx, VertxTestContext testContext) {
     vertx.createHttpServer()
       .requestHandler(request -> request.response().end("Plop"))
-      .listen(8080, testContext.completing());
+      .listen(8080, testContext.succeedingThenComplete());
   }
 
   @Test
@@ -183,7 +183,7 @@ public class Examples {
       // is successfully deployed
       @BeforeEach
       void deploy_verticle(Vertx vertx, VertxTestContext testContext) {
-        vertx.deployVerticle(new HttpServerVerticle(), testContext.completing());
+        vertx.deployVerticle(new HttpServerVerticle(), testContext.succeedingThenComplete());
       }
 
       // Repeat this test 3 times

--- a/src/main/java/examples/LifecycleExampleTest.java
+++ b/src/main/java/examples/LifecycleExampleTest.java
@@ -37,7 +37,7 @@ class LifecycleExampleTest {
   @BeforeEach
   @DisplayName("Deploy a verticle")
   void prepare(Vertx vertx, VertxTestContext testContext) {
-    vertx.deployVerticle(new SomeVerticle(), testContext.completing());
+    vertx.deployVerticle(new SomeVerticle(), testContext.succeedingThenComplete());
   }
 
   @Test

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -170,20 +170,6 @@ public final class VertxTestContext {
   // ........................................................................................... //
 
   /**
-   * Create an asynchronous result handler that expects a success.
-   *
-   * @param <T> the asynchronous result type.
-   * @return the handler.
-   */
-  public <T> Handler<AsyncResult<T>> succeeding() {
-    return ar -> {
-      if (!ar.succeeded()) {
-        failNow(ar.cause());
-      }
-    };
-  }
-
-  /**
    * Create an asynchronous result handler that expects a success, and passes the value to another handler.
    *
    * @param nextHandler the value handler to call on success.
@@ -197,20 +183,6 @@ public final class VertxTestContext {
         nextHandler.handle(ar.result());
       } else {
         failNow(ar.cause());
-      }
-    };
-  }
-
-  /**
-   * Create an asynchronous result handler that expects a failure.
-   *
-   * @param <T> the asynchronous result type.
-   * @return the handler.
-   */
-  public <T> Handler<AsyncResult<T>> failing() {
-    return ar -> {
-      if (ar.succeeded()) {
-        failNow(new AssertionError("The asynchronous result was expected to have failed"));
       }
     };
   }
@@ -238,6 +210,7 @@ public final class VertxTestContext {
    *
    * @param <T> the asynchronous result type.
    * @return the handler.
+   * @see #failingThenComplete()
    */
   public <T> Handler<AsyncResult<T>> completing() {
     return ar -> {
@@ -246,6 +219,23 @@ public final class VertxTestContext {
       } else {
         failNow(ar.cause());
       }
+    };
+  }
+
+  /**
+   * Create an asynchronous result handler that expects a failure to then complete the test context.
+   *
+   * @param <T> the asynchronous result type.
+   * @return the handler.
+   * @see #completing()
+   */
+  public <T> Handler<AsyncResult<T>> failingThenComplete() {
+    return ar -> {
+      if (ar.succeeded()) {
+        failNow(new AssertionError("The asynchronous result was expected to have failed"));
+        return;
+      }
+      completeNow();
     };
   }
 

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -170,6 +170,24 @@ public final class VertxTestContext {
   // ........................................................................................... //
 
   /**
+   * Create an asynchronous result handler that expects a success.
+   *
+   * @param <T> the asynchronous result type.
+   * @return the handler.
+   * @deprecated Use {@link #completing()} or {@link #succeeding(Handler)}, for example
+   *     <code>succeeding(value -> checkpoint.flag())</code>, <code>succeeding(value -> { more testing code })</code>, or
+   *     <code>succeeding(value -> {})</code>.
+   */
+  @Deprecated
+  public <T> Handler<AsyncResult<T>> succeeding() {
+    return ar -> {
+      if (!ar.succeeded()) {
+        failNow(ar.cause());
+      }
+    };
+  }
+
+  /**
    * Create an asynchronous result handler that expects a success, and passes the value to another handler.
    *
    * @param nextHandler the value handler to call on success.
@@ -183,6 +201,24 @@ public final class VertxTestContext {
         nextHandler.handle(ar.result());
       } else {
         failNow(ar.cause());
+      }
+    };
+  }
+
+  /**
+   * Create an asynchronous result handler that expects a failure.
+   *
+   * @param <T> the asynchronous result type.
+   * @return the handler.
+   * @deprecated Use {@link #failingThenComplete()} or {@link #failing(Handler)}, for example
+   *     <code>failing(e -> checkpoint.flag())</code>, <code>failing(e -> { more testing code })</code>, or
+   *     <code>failing(e -> {})</code>.
+   */
+  @Deprecated
+  public <T> Handler<AsyncResult<T>> failing() {
+    return ar -> {
+      if (ar.succeeded()) {
+        failNow(new AssertionError("The asynchronous result was expected to have failed"));
       }
     };
   }

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -174,7 +174,7 @@ public final class VertxTestContext {
    *
    * @param <T> the asynchronous result type.
    * @return the handler.
-   * @deprecated Use {@link #completing()} or {@link #succeeding(Handler)}, for example
+   * @deprecated Use {@link #succeedingThenComplete()} or {@link #succeeding(Handler)}, for example
    *     <code>succeeding(value -> checkpoint.flag())</code>, <code>succeeding(value -> { more testing code })</code>, or
    *     <code>succeeding(value -> {})</code>.
    */
@@ -254,9 +254,8 @@ public final class VertxTestContext {
    *
    * @param <T> the asynchronous result type.
    * @return the handler.
-   * @see #failingThenComplete()
    */
-  public <T> Handler<AsyncResult<T>> completing() {
+  public <T> Handler<AsyncResult<T>> succeedingThenComplete() {
     return ar -> {
       if (ar.succeeded()) {
         completeNow();
@@ -267,11 +266,23 @@ public final class VertxTestContext {
   }
 
   /**
+   * Create an asynchronous result handler that expects a success to then complete the test context.
+   *
+   * @param <T> the asynchronous result type.
+   * @return the handler.
+   * @see #failingThenComplete()
+   * @deprecated Use {@link #succeedingThenComplete()} instead.
+   */
+  @Deprecated
+  public <T> Handler<AsyncResult<T>> completing() {
+    return succeedingThenComplete();
+  }
+
+  /**
    * Create an asynchronous result handler that expects a failure to then complete the test context.
    *
    * @param <T> the asynchronous result type.
    * @return the handler.
-   * @see #completing()
    */
   public <T> Handler<AsyncResult<T>> failingThenComplete() {
     return ar -> {

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -272,19 +272,19 @@ class VertxTestContextTest {
   }
 
   @Test
-  @DisplayName("Pass a success to a completing() async handler")
-  void check_completing_success() throws InterruptedException {
+  @DisplayName("Pass a success to a succeedingThenComplete() async handler")
+  void check_succeedingThenComplete_success() throws InterruptedException {
     VertxTestContext context = new VertxTestContext();
-    context.completing().handle(Future.succeededFuture());
+    context.succeedingThenComplete().handle(Future.succeededFuture());
     assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
     assertThat(context.completed()).isTrue();
   }
 
   @Test
-  @DisplayName("Pass a failure to a completing() async handler")
-  void check_completing_failure() throws InterruptedException {
+  @DisplayName("Pass a failure to a succeedingThenComplete() async handler")
+  void check_succeedingThenComplete_failure() throws InterruptedException {
     VertxTestContext context = new VertxTestContext();
-    context.completing().handle(Future.failedFuture(new RuntimeException("Boo!")));
+    context.succeedingThenComplete().handle(Future.failedFuture(new RuntimeException("Boo!")));
     assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
     assertThat(context.completed()).isFalse();
     assertThat(context.failed()).isTrue();

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -43,6 +43,38 @@ class VertxTestContextTest {
   }
 
   @Test
+  @DisplayName("Check the behavior of succeeding() and that it does not complete the test context")
+  void check_async_assert() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.succeeding().handle(Future.succeededFuture());
+    assertThat(context.awaitCompletion(1, TimeUnit.MILLISECONDS)).isFalse();
+    assertThat(context.completed()).isFalse();
+
+    context = new VertxTestContext();
+    context.succeeding().handle(Future.failedFuture(new RuntimeException("Plop")));
+    assertThat(context.awaitCompletion(1, TimeUnit.MILLISECONDS)).isTrue();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessage("Plop");
+  }
+
+  @Test
+  @DisplayName("Check the behavior of failing()")
+  void check_async_assert_fail() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.failing().handle(Future.failedFuture("Bam"));
+    context.awaitCompletion(1, TimeUnit.MILLISECONDS);
+    assertThat(context.failed()).isFalse();
+
+    context = new VertxTestContext();
+    context.failing().handle(Future.succeededFuture());
+    context.awaitCompletion(1, TimeUnit.MILLISECONDS);
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure()).hasMessage("The asynchronous result was expected to have failed");
+  }
+
+  @Test
   @DisplayName("Check the behavior of succeeding(callback)")
   void check_async_assert_with_handler() throws InterruptedException {
     AtomicBoolean checker = new AtomicBoolean(false);

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -43,38 +43,6 @@ class VertxTestContextTest {
   }
 
   @Test
-  @DisplayName("Check the behavior of succeeding() and that it does not complete the test context")
-  void check_async_assert() throws InterruptedException {
-    VertxTestContext context = new VertxTestContext();
-    context.succeeding().handle(Future.succeededFuture());
-    assertThat(context.awaitCompletion(1, TimeUnit.MILLISECONDS)).isFalse();
-    assertThat(context.completed()).isFalse();
-
-    context = new VertxTestContext();
-    context.succeeding().handle(Future.failedFuture(new RuntimeException("Plop")));
-    assertThat(context.awaitCompletion(1, TimeUnit.MILLISECONDS)).isTrue();
-    assertThat(context.failed()).isTrue();
-    assertThat(context.causeOfFailure())
-      .isInstanceOf(RuntimeException.class)
-      .hasMessage("Plop");
-  }
-
-  @Test
-  @DisplayName("Check the behavior of failing()")
-  void check_async_assert_fail() throws InterruptedException {
-    VertxTestContext context = new VertxTestContext();
-    context.failing().handle(Future.failedFuture("Bam"));
-    context.awaitCompletion(1, TimeUnit.MILLISECONDS);
-    assertThat(context.failed()).isFalse();
-
-    context = new VertxTestContext();
-    context.failing().handle(Future.succeededFuture());
-    context.awaitCompletion(1, TimeUnit.MILLISECONDS);
-    assertThat(context.failed()).isTrue();
-    assertThat(context.causeOfFailure()).hasMessage("The asynchronous result was expected to have failed");
-  }
-
-  @Test
   @DisplayName("Check the behavior of succeeding(callback)")
   void check_async_assert_with_handler() throws InterruptedException {
     AtomicBoolean checker = new AtomicBoolean(false);
@@ -257,6 +225,30 @@ class VertxTestContextTest {
     assertThat(context.completed()).isFalse();
     assertThat(context.failed()).isTrue();
     assertThat(context.causeOfFailure()).hasMessage("Boo!");
+  }
+
+  @Test
+  @DisplayName("Pass a failure to a failingThenComplete() async handler")
+  void check_failingThenComplete_failure() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.failingThenComplete().handle(Future.failedFuture(new IllegalArgumentException("42")));
+    assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.failed()).isFalse();
+    assertThat(context.completed()).isTrue();
+    assertThat(context.causeOfFailure()).isNull();
+  }
+
+  @Test
+  @DisplayName("Pass a success to a failingThenComplete() async handler")
+  void check_failingThenComplete_success() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    context.failingThenComplete().handle(Future.succeededFuture("gold"));
+    assertThat(context.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.completed()).isFalse();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure())
+    .isInstanceOf(AssertionError.class)
+    .hasMessage("The asynchronous result was expected to have failed");
   }
 
   @Test


### PR DESCRIPTION
Using the parameter-less method VertxTestContext#succeeding()
is almost always unintended and should be replaced by

* completing()
* succeeding(value -> checkpoint.flag())
* succeeding(value -> { more testing code })
* succeeding(value -> {})

The same for failing().

Deprecating for removal the methods succeeding() and failing() improves
VertxTestContext's ergonomics because people are no longer
tempted to use them. The replacement either fixes an unintended
bug in people's unit test code or is more readable because
it explicitly states the intention.

Example for unintended succeeding() usage that is not executed:
https://github.com/reactiverse/reactiverse-junit5-extensions/pull/3/files

The new method failingThenComplete() is a short-cut for
failing(exception -> vertxTestContext.completeNow())
and parallels completing() that is an existing short-cut for
succeeding(value -> vertxTestContext.completeNow()).

Note that vertx-unit's TestContext#asyncAssertSuccess() and
TestContext#asyncAssertFailure() are different because they
complete the test context by design. People switching from
vertx-unit to vertx-junit5 will not fall into this trap if we
remove succeeding() and failing().

Fixes #77.