### PR TITLE
Fail on exception in nextHandler of succeeding and failing

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -48,7 +48,7 @@ Here is a very basic usage:
 This module does not make any assumption on the assertion library that you should be using.
 You can use plain JUnit assertions, http://joel-costigliola.github.io/assertj/[AssertJ], etc.
 
-To make assertions in asynchronous code and make sure that {@link io.vertx.junit5.VertxTestContext} is notified of potential failures, you need to wrap them with a call to {@link io.vertx.junit5.VertxTestContext#verify}:
+To make assertions in asynchronous code and make sure that {@link io.vertx.junit5.VertxTestContext} is notified of potential failures, you need to wrap them with a call to {@link io.vertx.junit5.VertxTestContext#verify}, {@link io.vertx.junit5.VertxTestContext#succeeding(io.vertx.core.Handler)}, or {@link io.vertx.junit5.VertxTestContext#failing(io.vertx.core.Handler)}:
 
 [source,java]
 ----
@@ -59,8 +59,8 @@ The useful methods in {@link io.vertx.junit5.VertxTestContext} are the following
 
 * {@link io.vertx.junit5.VertxTestContext#completeNow} and {@link io.vertx.junit5.VertxTestContext#failNow} to notify of a success or failure
 * {@link io.vertx.junit5.VertxTestContext#completing} to provide `Handler<AsyncResult<T>>` handlers that expect a success and then completes the test context
-* {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success, and optionally pass the result to another callback
-* {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure, and optionally pass the exception to another callback
+* {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success, and optionally pass the result to another callback, any exception thrown from the callback is considered as a test failure
+* {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure, and optionally pass the exception to another callback, any exception thrown from the callback is considered as a test failure
 * {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the code block is considered as a test failure.
 
 WARNING: Unlike `completing()`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -18,6 +18,8 @@ package io.vertx.junit5;
 
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +106,21 @@ class VertxTestContextTest {
   }
 
   @Test
+  @DisplayName("Check callback exception of succeeding(callback)")
+  void check_succeeding_callback_with_exception() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    Handler<Object> nextHandler = obj -> {
+      throw new RuntimeException("Boom");
+    };
+    context.succeeding(nextHandler).handle(Future.succeededFuture());
+    assertThat(context.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessage("Boom");
+  }
+
+  @Test
   @DisplayName("Check the behavior of failing(callback)")
   void check_async_assert_fail_with_handler() throws InterruptedException {
     AtomicBoolean checker = new AtomicBoolean(false);
@@ -127,6 +144,21 @@ class VertxTestContextTest {
     assertThat(context.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
     assertThat(context.failed()).isTrue();
     assertThat(context.causeOfFailure()).hasMessage("The asynchronous result was expected to have failed");
+  }
+
+  @Test
+  @DisplayName("Check callback exception of failing(callback)")
+  void check_failing_callback_with_exception() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+    Handler<Throwable> nextHandler = throwable -> {
+      throw new RuntimeException("Pow");
+    };
+    context.failing(nextHandler).handle(Future.failedFuture("some failure"));
+    assertThat(context.awaitCompletion(2, TimeUnit.SECONDS)).isTrue();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessage("Pow");
   }
 
   @Test


### PR DESCRIPTION
VertxTestContext will immediately fail the test if nextHandler
of succeeding(nextHandler) or failing(nextHandler) throws an
exception (any Throwable).

Why should succeeding(nextHandler) and failing(nextHandler)
catch any exception that nextHandler throws?

We write tests to let VertxTestContext find and report bugs.
All failed assertions must fail the test.
If the test code or the code under test throws an exception
it is almost always unintended and a bug and should also fail
the test and report that exception including the stacktrace.

Exceptions should fail the test by default without the need
to manually wrap the test code into verify(...).

Why is this not a breaking change?

Currently it is not documented and therefore undefined how
VertxTestContext handles exceptions thrown by nextHandler:
https://github.com/vert-x3/vertx-junit5/blob/4.0.0-milestone4/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java#L175
https://github.com/vert-x3/vertx-junit5/blob/4.0.0-milestone4/vertx-junit5/src/main/java/io/vertx/junit5/VertxTestContext.java#L206

How does this feature correspond to vertx-unit?

The implementations of vertx-junit TestContext
asyncAssertSuccess(Handler<T> resultHandler) and
asyncAssertFailure(Handler<Throwable> causeHandler) fail the
test if the handler throws an exception:
https://github.com/vert-x3/vertx-unit/blob/4.0.0-milestone4/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java#L318
https://github.com/vert-x3/vertx-unit/blob/4.0.0-milestone4/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java#L342

This (undocumented) vertx-unit feature should be carried forward
into vertx-junit5 succeeding and failing methods.

How does this feature improve test reporting ergonomics?

An exception that is ignored usually results in a
test timeout. The timeout message contains no indication
that there was an exception.

If the test fails because of an exception in the nextHandler
code block the exception message and the exception stack trace
is reported to the testing framework (for example JUnit).
This information is available on the command line and in IDEs
and help developers to pinpoint and fix the problem.

How does this feature improve test writing ergonomics?

It reduces the boilerplate.

```
testContext.succeeding(response -> testContext.verify(() -> {
  ...
}))
```

is reduced to

```
testContext.succeeding(response -> {
  ...
})
```

and therefore improves readability by avoiding to wrap the inner
test code into yet another lambda.

Developers cannot unintentionally forget to add vertify(...) when
using succeeding(...) or failing(...).

This feature is almost always the expected behaviour.

How can an exception still been ignored as before?

```
testContext.succeeding(response -> {
  try {
    // some test code
  } catch (Throwable e) {
    return;
  }
})
```

This pull request obsoletes #63