### PR TITLE
Removed bad docs

### DIFF
--- a/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/TestRequest.java
+++ b/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/TestRequest.java
@@ -47,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * This class is a wrapper around {@link WebClient} that simplifies the creation of Http requests and the asserts on responses.
  *
  * @author <a href="https://slinkydeveloper.com">Francesco Guardiani</a>
+ * @deprecated From Vert.x 4 onward this package lives in reactiverse as <a href="https://github.com/reactiverse/reactiverse-junit5-extensions/">reactiverse-junit5-extensions</a>
  */
 public class TestRequest {
 

--- a/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/VertxWebClientExtension.java
+++ b/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/VertxWebClientExtension.java
@@ -44,6 +44,7 @@ import java.util.Optional;
  * with type {@link WebClientOptions} annotated with {@link WebClientOptionsInject}
  *
  * @author <a href="https://slinkydeveloper.com">Francesco Guardiani</a>
+ * @deprecated From Vert.x 4 onward this package lives in reactiverse as <a href="https://github.com/reactiverse/reactiverse-junit5-extensions/">reactiverse-junit5-extensions</a>
  */
 public class VertxWebClientExtension implements ParameterResolver {
 

--- a/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/WebClientOptionsInject.java
+++ b/vertx-junit5-web-client/src/main/java/io/vertx/junit5/web/WebClientOptionsInject.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * Look at {@link VertxWebClientExtension} for more details
  *
  * @author <a href="https://slinkydeveloper.com">Francesco Guardiani</a>
+ * @deprecated From Vert.x 4 onward this package lives in reactiverse as <a href="https://github.com/reactiverse/reactiverse-junit5-extensions/">reactiverse-junit5-extensions</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})

--- a/vertx-junit5/src/main/asciidoc/index.adoc
+++ b/vertx-junit5/src/main/asciidoc/index.adoc
@@ -175,9 +175,3 @@ Instances of these _"Rx-ified"_ `Vertx` classes can be injected in test and life
 ----
 {@link examples.RxJava2Test}
 ----
-
-== JUnit 5 additional extensions
-
-Vert.x provides additional modules to simplify testing of your Vert.x application:
-
-* https://vertx.io/docs/vertx-junit5-web-client/$lang/[Vert.x Junit 5 Web Client] to use https://vertx.io/docs/vertx-web-client/$lang/[Vert.x Web Client] to create Http requests in your tests and simplify assertions on responses


### PR DESCRIPTION
Fix https://github.com/eclipse-vertx/vert.x/issues/3544

vertx-junit5-web-client now lives in reactiverse and this package should not be used anymore