### PR TITLE
Adding the ability to provide VertxOptions from the environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
 
@@ -36,6 +37,7 @@
     <assertj-core.version>3.14.0</assertj-core.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <junit-platform-launcher.version>1.7.0</junit-platform-launcher.version>
+    <system-lamda.version>1.2.0</system-lamda.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 
@@ -70,14 +72,22 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>${system-lamda.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-jupiter.version}</version>
     </dependency>
+
     <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${junit-jupiter.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -149,7 +149,7 @@ Generally-speaking, we respect the JUnit extension scoping rules, but here are t
 3. Injecting in a `@BeforeEach` with no parent context or previous `@BeforeAll` injection creates a new instance shared with the corresponding test and `AfterEach` method(s).
 4. When no instance exists before running a test method, an instance is created for that test (and only for that test).
 
-==== Configuring of `Vertx` objects
+==== Configuring `Vertx` instances
 
 By default the `Vertx` objects get created with `Vertx.vertx()`, using the default settings for `Vertx`. However you have the ability to configure `VertxOptions` to suit your needs.
 A typical use case would be "extending blocking timeout warning for debugging". To configure the `Vertx` object you must:

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -149,6 +149,16 @@ Generally-speaking, we respect the JUnit extension scoping rules, but here are t
 3. Injecting in a `@BeforeEach` with no parent context or previous `@BeforeAll` injection creates a new instance shared with the corresponding test and `AfterEach` method(s).
 4. When no instance exists before running a test method, an instance is created for that test (and only for that test).
 
+==== Configuring of `Vertx` objects
+
+By default the `Vertx` objects get created with `Vertx.vertx()`, using the default settings for `Vertx`. However you have the ability to configure `VertxOptions` to suit your needs.
+A typical use case would be "extending blocking timeout warning for debugging". To configure the `Vertx` object you must:
+
+1. create a json file with the `VertxOptions` in https://vertx.io/docs/apidocs/io/vertx/core/VertxOptions.html#VertxOptions-io.vertx.core.json.JsonObject-[json format] 
+2. create an environment variable `vertx.parameter.filename` pointing to that file
+
+With these conditions met, the `Vertx` object will be created with the configured options
+
 ==== Closing and removal of `Vertx` objects
 
 Injected `Vertx` objects are being automatically closed and removed from their corresponding scopes.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -157,6 +157,16 @@ A typical use case would be "extending blocking timeout warning for debugging". 
 1. create a json file with the `VertxOptions` in https://vertx.io/docs/apidocs/io/vertx/core/VertxOptions.html#VertxOptions-io.vertx.core.json.JsonObject-[json format] 
 2. create an environment variable `vertx.parameter.filename` pointing to that file
 
+Example file content for extended timeouts:
+
+[source,json]
+{
+  "blockedThreadCheckInterval" : 5,
+  "blockedThreadCheckIntervalUnit" : "MINUTES",
+  "maxEventLoopExecuteTime" : 360,
+  "maxEventLoopExecuteTimeUnit" : "SECONDS"
+}
+
 With these conditions met, the `Vertx` object will be created with the configured options
 
 ==== Closing and removal of `Vertx` objects

--- a/src/test/java/io/vertx/junit5/VertxParameterProviderTest.java
+++ b/src/test/java/io/vertx/junit5/VertxParameterProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author <a href="https://wissel.net/">Stephan Wisssel</a>
+ */
+@DisplayName("Test of VertxParameterProvider")
+public class VertxParameterProviderTest {
+
+    @Test
+    @DisplayName("Default case - empty VertxOptions")
+    void default_empty_options() {
+        VertxParameterProvider provider = new VertxParameterProvider();
+        JsonObject expected = new JsonObject();
+        JsonObject actual = provider.getVertxOptions();
+        assertEquals(expected.encode(), actual.encode(), "Options should be equally empty but are not");
+    }
+
+    @Test
+    @DisplayName("Failed retrieval of options")
+    void failed_retrieval_of_options() throws Exception {
+        VertxParameterProvider provider = new VertxParameterProvider();
+        final JsonObject expected = new JsonObject();
+        final JsonObject actual = new JsonObject();
+
+        withEnvironmentVariable(VertxParameterProvider.VERTX_PARAMETER_FILENAME, "something.that.does.not.exist.json")
+                .execute(() -> {
+                    actual.mergeIn(provider.getVertxOptions());
+                });
+
+        assertEquals(expected.encode(), actual.encode(), "Options retrival failure not handled");
+    }
+
+    @Test
+    @DisplayName("Retrieval of options")
+    void retrieval_of_options() throws Exception {
+        VertxParameterProvider provider = new VertxParameterProvider();
+        final JsonObject expected = new JsonObject().put("BlockedThreadCheckInterval", 120).put("MaxWorkerExecuteTime",
+                42);
+        final JsonObject actual = new JsonObject();
+        // Create a temp file and populate it with our expected values
+        File tempOptionFile = File.createTempFile("VertxOptions-", ".json");
+        tempOptionFile.deleteOnExit();
+        BufferedWriter writer = new BufferedWriter(new FileWriter(tempOptionFile.getAbsolutePath()));
+        writer.write(expected.encode());
+        writer.close();
+
+        withEnvironmentVariable(VertxParameterProvider.VERTX_PARAMETER_FILENAME, tempOptionFile.getAbsolutePath())
+                .execute(() -> {
+                    actual.mergeIn(provider.getVertxOptions());
+                });
+
+        assertEquals(expected.encode(), actual.encode(), "Options retrival failed");
+    }
+
+}


### PR DESCRIPTION
- amended the VertxParameterProvider
- created TestClass

Motivation:

Reopening of #99 after fixing committer identity.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
