### PR TITLE
Extension for running jUnit5 tests on a Vert.x context

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -227,3 +227,26 @@ the method definition.
 
 The same holds for the other `ArgumentSources`. See the section `Formal Parameter List` in the API doc of
 https://junit.org/junit5/docs/current/api/org.junit.jupiter.params/org/junit/jupiter/params/ParameterizedTest.html[ParameterizedTest]
+
+== Running tests on a Vert.x context
+
+By default the thread invoking the test methods is the JUnit thread.
+The {@link io.vertx.junit5.RunTestOnContext} extension can be used to alter this behavior by running test methods on a Vert.x event-loop thread.
+
+CAUTION: Keep in mind that you must not block the event loop when using this extension.
+
+For this purpose, the extension needs a {@link io.vertx.core.Vertx} instance.
+By default, it creates one automatically but you can provide options for configuration or a supplier method.
+
+The {@link io.vertx.core.Vertx} instance can be retrieved when the test is running.
+
+[source,java]
+----
+{@link examples.RunTestOnContextExampleTest}
+----
+
+When used as a `@RegisterExtension` instance field, a new {@link io.vertx.core.Vertx} object and {@link io.vertx.core.Context} are created for each tested method.
+`@BeforeEach` and `@AfterEach` methods are executed on this context.
+
+When used as a `@RegisterExtension` static field, a single {@link io.vertx.core.Vertx} object and {@link io.vertx.core.Context} are created for all the tested methods.
+`@BeforeAll` and `@AfterAll` methods are executed on this context too.

--- a/src/main/java/examples/RunTestOnContextExampleTest.java
+++ b/src/main/java/examples/RunTestOnContextExampleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RunTestOnContextExampleTest {
+
+  @RegisterExtension
+  RunTestOnContext rtoc = new RunTestOnContext();
+
+  Vertx vertx;
+
+  @BeforeEach
+  void prepare(VertxTestContext testContext) {
+    vertx = rtoc.vertx();
+    // Prepare something on a Vert.x event-loop thread
+    // The thread changes with each test instance
+    testContext.completeNow();
+  }
+
+  @Test
+  void foo(VertxTestContext testContext) {
+    // Test something on the same Vert.x event-loop thread
+    // that called prepare
+    testContext.completeNow();
+  }
+
+  @AfterEach
+  void cleanUp(VertxTestContext testContext) {
+    // Clean things up on the same Vert.x event-loop thread
+    // that called prepare and foo
+    testContext.completeNow();
+  }
+}

--- a/src/main/java/io/vertx/junit5/RunTestOnContext.java
+++ b/src/main/java/io/vertx/junit5/RunTestOnContext.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import io.vertx.core.*;
+import io.vertx.core.impl.VertxInternal;
+import org.junit.jupiter.api.extension.*;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * An extension that runs tests on a Vert.x context.
+ * <p>
+ * When used as a {@link RegisterExtension} instance field, a new {@link Vertx} object and {@link Context} are created for each tested method.
+ * {@link org.junit.jupiter.api.BeforeEach} and {@link org.junit.jupiter.api.AfterEach} methods are executed on this context.
+ * <p>
+ * When used as a {@link RegisterExtension} static field, a single {@link Vertx} object and {@link Context} are created for all the tested methods.
+ * {@link org.junit.jupiter.api.BeforeAll} and {@link org.junit.jupiter.api.AfterAll} methods are executed on this context too.
+ */
+public class RunTestOnContext implements BeforeAllCallback, InvocationInterceptor, AfterEachCallback, AfterAllCallback {
+
+  private volatile boolean staticExtension;
+
+  private volatile Vertx vertx;
+  private volatile Context context;
+
+  private final Supplier<Future<Vertx>> supplier;
+  private final Function<Vertx, Future<Void>> shutdown;
+
+  /**
+   * Create an instance of this extension that builds a {@link Vertx} object using default options.
+   */
+  public RunTestOnContext() {
+    this(new VertxOptions());
+  }
+
+  /**
+   * Create an instance of this extension that builds a {@link Vertx} object using the specified {@code options}.
+   * <p>
+   * When the options hold a {@link io.vertx.core.spi.cluster.ClusterManager} instance, a clustered {@link Vertx} object is created.
+   *
+   * @param options the vertx options
+   */
+  public RunTestOnContext(VertxOptions options) {
+    this(() -> options.getClusterManager() != null ? Vertx.clusteredVertx(options) : Future.succeededFuture(Vertx.vertx(options)));
+  }
+
+  /**
+   * Create an instance of this extension that gets a {@link Vertx} object using the specified asynchronous {@code supplier}.
+   *
+   * @param supplier the asynchronous supplier
+   */
+  public RunTestOnContext(Supplier<Future<Vertx>> supplier) {
+    this(supplier, Vertx::close);
+  }
+
+  /**
+   * Create an instance of this extension that gets a {@link Vertx} object using the specified asynchronous {@code supplier}.
+   * The asynchronous {@code shutdown} function is invoked when the {@link Vertx} object is no longer needed.
+   *
+   * @param supplier the asynchronous supplier
+   * @param shutdown the asynchronous shutdown function
+   */
+  public RunTestOnContext(Supplier<Future<Vertx>> supplier, Function<Vertx, Future<Void>> shutdown) {
+    this.supplier = supplier;
+    this.shutdown = shutdown;
+  }
+
+  /**
+   * @return the current Vert.x instance
+   */
+  public Vertx vertx() {
+    return vertx;
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    staticExtension = true;
+  }
+
+  @Override
+  public void interceptBeforeAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public <T> T interceptTestFactoryMethod(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    return runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptTestTemplateMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptDynamicTest(Invocation<Void> invocation, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  @Override
+  public void interceptAfterAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    runOnContext(invocation);
+  }
+
+  private <T> T runOnContext(Invocation<T> invocation) throws Throwable {
+    Future<Vertx> vertxFuture;
+    if (vertx != null) {
+      vertxFuture = Future.succeededFuture(vertx);
+    } else {
+      vertxFuture = supplier.get().onSuccess(vertx -> {
+        this.vertx = vertx;
+        context = ((VertxInternal) vertx).createEventLoopContext();
+      });
+    }
+    CompletableFuture<T> cf = vertxFuture
+      .compose(ignore -> {
+        Promise<T> promise = Promise.promise();
+        context.runOnContext(v -> {
+          try {
+            promise.complete(invocation.proceed());
+          } catch (Throwable e) {
+            promise.fail(e);
+          }
+        });
+        return promise.future();
+      })
+      .toCompletionStage()
+      .toCompletableFuture();
+    try {
+      return cf.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
+    } catch (ExecutionException e) {
+      throw e.getCause();
+    }
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    if (staticExtension) {
+      return;
+    }
+    cleanUp();
+  }
+
+  private void cleanUp() throws Exception {
+    context = null;
+    if (vertx == null) {
+      return;
+    }
+    Future<Void> closeFuture = shutdown.apply(vertx);
+    vertx = null;
+    try {
+      closeFuture.toCompletionStage().toCompletableFuture().get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      throw new RuntimeException(cause);
+    }
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    cleanUp();
+  }
+}

--- a/src/test/java/io/vertx/junit5/CustomizedRunOnContextExtensionTest.java
+++ b/src/test/java/io/vertx/junit5/CustomizedRunOnContextExtensionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CustomizedRunOnContextExtensionTest {
+
+  static AtomicInteger destroyMethodInvocations = new AtomicInteger();
+  Vertx expectedVertx;
+
+  @RegisterExtension
+  RunTestOnContext testOnContext = new RunTestOnContext(() -> {
+    expectedVertx = Vertx.vertx();
+    return Future.succeededFuture(expectedVertx);
+  }, vertx -> {
+    destroyMethodInvocations.incrementAndGet();
+    assertSame(expectedVertx, vertx);
+    return vertx.close();
+  });
+
+  @BeforeEach
+  void beforeTest() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(expectedVertx, ctx.owner());
+  }
+
+  @Test
+  void testMethod1() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(expectedVertx, ctx.owner());
+  }
+
+  @Test
+  void testMethod2() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(expectedVertx, ctx.owner());
+  }
+
+  @AfterEach
+  void tearDown() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(expectedVertx, ctx.owner());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    assertEquals(2, destroyMethodInvocations.get());
+  }
+}

--- a/src/test/java/io/vertx/junit5/RunOnContextExtensionTest.java
+++ b/src/test/java/io/vertx/junit5/RunOnContextExtensionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.vertx.junit5.StaticRunOnContextExtensionTest.checkContext;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RunOnContextExtensionTest {
+
+  @RegisterExtension
+  RunTestOnContext testOnContext = new RunTestOnContext();
+
+  AtomicReference<Context> ctxRef = new AtomicReference<>();
+
+  @BeforeAll
+  static void beforeAll() {
+    assertNull(Vertx.currentContext());
+  }
+
+  public RunOnContextExtensionTest() {
+    assertNull(Vertx.currentContext());
+  }
+
+  @BeforeEach
+  void beforeTest() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(ctx.owner(), testOnContext.vertx());
+    assertNotSame(ctx, ctxRef.getAndSet(ctx));
+  }
+
+  @Test
+  void testMethod1() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @Test
+  void testMethod2() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @AfterEach
+  void tearDown() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    assertNull(Vertx.currentContext());
+  }
+}

--- a/src/test/java/io/vertx/junit5/StaticRunOnContextExtensionTest.java
+++ b/src/test/java/io/vertx/junit5/StaticRunOnContextExtensionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.junit5;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith({VertxExtension.class})
+public class StaticRunOnContextExtensionTest {
+
+  @RegisterExtension
+  static RunTestOnContext testOnContext = new RunTestOnContext();
+
+  static AtomicReference<Context> ctxRef = new AtomicReference<>();
+
+  @BeforeAll
+  static void beforeAll() {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(ctx.owner(), testOnContext.vertx());
+    ctxRef.set(ctx);
+  }
+
+  public StaticRunOnContextExtensionTest() {
+    assertNull(Vertx.currentContext());
+  }
+
+  @BeforeEach
+  void beforeTest() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @Test
+  void testMethod1() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @Test
+  void testMethod2() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @AfterEach
+  void tearDown() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    checkContext(testOnContext.vertx(), ctxRef.get());
+  }
+
+  static void checkContext(Vertx expectedVertx, Context expectedContext) {
+    Context ctx = Vertx.currentContext();
+    assertNotNull(ctx);
+    assertSame(expectedVertx, ctx.owner());
+    assertSame(expectedContext, ctx);
+  }
+}


### PR DESCRIPTION
Closes #100

vertx-unit has a RunTestOnContext rule that had no equivalent in vertx-junit5.