### PR TITLE
Use system-stubs-core for testing instead of system-lambda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <junit-jupiter.version>5.14.0</junit-jupiter.version>
     <apiguardian-api.version>1.0.0</apiguardian-api.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <system-lamda.version>1.2.1</system-lamda.version>
   </properties>
 
   <dependencyManagement>
@@ -113,9 +112,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-lambda</artifactId>
-      <version>${system-lamda.version}</version>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-core</artifactId>
+      <version>2.1.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -182,7 +181,7 @@
     <profile>
       <id>java17-running-test-with-strong-encapsulation</id>
       <activation>
-        <jdk>17</jdk>
+        <jdk>[17,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/src/test/java/io/vertx/junit5/tests/VertxParameterProviderTest.java
+++ b/src/test/java/io/vertx/junit5/tests/VertxParameterProviderTest.java
@@ -20,23 +20,20 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxParameterProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.EnabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.*;
 import static io.vertx.junit5.VertxParameterProvider.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 /**
  * @author <a href="https://wissel.net/">Stephan Wisssel</a>
  */
 @DisplayName("Test of VertxParameterProvider")
-@EnabledOnJre(value = JRE.JAVA_11)
 public class VertxParameterProviderTest {
 
   VertxParameterProvider provider = new VertxParameterProvider();

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -5,5 +5,5 @@ open module io.vertx.testing.junit5.tests {
   requires org.junit.platform.launcher;
   requires org.assertj.core;
   requires org.junit.jupiter.api;
-  requires system.lambda;
+  requires system.stubs.core;
 }


### PR DESCRIPTION
system-stubs-core is compatible with all versions of the JDK currently supported by Vert.x