### PR TITLE
ScopedObject should implement AutoCloseable

### DIFF
--- a/src/main/java/io/vertx/junit5/ScopedObject.java
+++ b/src/main/java/io/vertx/junit5/ScopedObject.java
@@ -16,8 +16,6 @@
 
 package io.vertx.junit5;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -29,7 +27,7 @@ import java.util.function.Supplier;
  * @param <T> Parameter type
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
-public class ScopedObject<T> implements Supplier<T>, ExtensionContext.Store.CloseableResource {
+public class ScopedObject<T> implements Supplier<T>, AutoCloseable {
 
   private T object;
   private final ParameterClosingConsumer<T> cleaner;
@@ -41,7 +39,7 @@ public class ScopedObject<T> implements Supplier<T>, ExtensionContext.Store.Clos
   }
 
   @Override
-  public void close() throws Throwable {
+  public void close() throws Exception {
     cleaner.accept(object);
   }
 


### PR DESCRIPTION
Fixes the following warning: 

```
org.junit.jupiter.engine.descriptor.AbstractExtensionContext msg=Type implements CloseableResource but not AutoCloseable: io.vertx.junit5.ScopedObject   
```

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

https://github.com/eclipse-vertx/vertx-junit5/pull/145#issuecomment-3773934750

