### PR TITLE
ScopedObject should implement AutoCloseable

### DIFF
--- a/src/main/java/io/vertx/junit5/ScopedObject.java
+++ b/src/main/java/io/vertx/junit5/ScopedObject.java
@@ -16,6 +16,8 @@
 
 package io.vertx.junit5;
 
+import org.junit.jupiter.api.extension.ExtensionContext;
+
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -27,7 +29,7 @@ import java.util.function.Supplier;
  * @param <T> Parameter type
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
-public class ScopedObject<T> implements Supplier<T>, AutoCloseable {
+public class ScopedObject<T> implements Supplier<T>, ExtensionContext.Store.CloseableResource, AutoCloseable {
 
   private T object;
   private final ParameterClosingConsumer<T> cleaner;


### PR DESCRIPTION
Fixes the following warning: 

```
org.junit.jupiter.engine.descriptor.AbstractExtensionContext msg=Type implements CloseableResource but not AutoCloseable: io.vertx.junit5.ScopedObject   
```

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

https://github.com/eclipse-vertx/vertx-junit5/pull/145#issuecomment-3773934750

