### PR TITLE
Support vertx instance instrumentation in the absence of test context.

### DIFF
--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -162,8 +162,15 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
   private void setupVertxInstances(ExtensionContext extensionContext) {
     Store store = extensionContext.getStore(Namespace.GLOBAL);
     ScopedObject<Vertx> scopedVertx = (ScopedObject<Vertx>)store.get(VERTX_INSTANCE_KEY);
-    ContextList entries = (ContextList)store.get(TEST_CONTEXT_KEY);
-    if (instrumentVertx(extensionContext) && scopedVertx != null && entries != null) {
+    if (instrumentVertx(extensionContext) && scopedVertx != null) {
+      ContextList entries = (ContextList)store.get(TEST_CONTEXT_KEY);
+      if (entries == null) {
+        // Create an implicit test context that is never a parameter but required to report test failures
+        VertxTestContext context = newTestContext(extensionContext);
+        // Fake checkpoint required to switch the test context to checkpoint mode to get the test completed
+        context.checkpoint().flag();
+        entries = (ContextList)store.get(TEST_CONTEXT_KEY);
+      }
       List<VertxTestContext> testContexts = entries
         .stream()
         .map(entry -> entry.context)

--- a/src/test/java/io/vertx/junit5/tests/VertxExtensionAnnotationTest.java
+++ b/src/test/java/io/vertx/junit5/tests/VertxExtensionAnnotationTest.java
@@ -166,7 +166,6 @@ public class VertxExtensionAnnotationTest {
     }
   }
 
-  @Disabled("Requires to use a VertxTestContext argument")
   @Test()
   public void testReportFailureBare() {
     TestExecutionSummary summary = VertxParameterProviderLifeCycleTest.runTests(TestReportFailureBare.class);


### PR DESCRIPTION
Motivation:

Vertx instrumentation requires a vertx test context to report failures to.

When the method does not declare such test context, should exist for the purpose of failure reporting by the instrumented vertx instance.

Changes:

When an instance needs to be instrumented, a vertx test context should be implicitely created, this context will never be injected and collect test failures to they can be reported.
