### PR TITLE
Improvements

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -90,8 +90,10 @@ Many tests can be marked as passed by simply calling {@link io.vertx.junit5.Vert
 That being said there are also many cases where the success of a test depends on different asynchronous parts to be validated.
 
 You can use checkpoints to flag some execution points to be passed.
-A {@link io.vertx.junit5.Checkpoint} can require a single flagging, or multiple flags.
-When all checkpoints have been flagged, then the corresponding {@link io.vertx.junit5.VertxTestContext} makes the test pass.
+
+When all checkpoints have been succeeded, then the corresponding {@link io.vertx.junit5.VertxTestContext} makes the test pass.
+
+A latch can be created out of a checkpoint when multiple passes are required
 
 Here is an example with checkpoints on the HTTP server being started, 10 HTTP requests having being responded, and 10 HTTP client requests having been made:
 

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -118,13 +119,13 @@ public class Examples {
   @Test
   public void checkpointing(Vertx vertx, VertxTestContext testContext) {
     Checkpoint serverStarted = testContext.checkpoint();
-    Checkpoint requestsServed = testContext.checkpoint(10);
-    Checkpoint responsesReceived = testContext.checkpoint(10);
+    CountDownLatch requestsServed = testContext.checkpoint().asLatch(10);
+    CountDownLatch responsesReceived = testContext.checkpoint().asLatch(10);
 
     vertx.createHttpServer()
       .requestHandler(req -> {
         req.response().end("Ok");
-        requestsServed.flag();
+        requestsServed.countDown();
       })
       .listen(8888)
       .onComplete(testContext.succeeding(httpServer -> {
@@ -136,7 +137,7 @@ public class Examples {
             .compose(req -> req.send().compose(HttpClientResponse::body))
             .onComplete(testContext.succeeding(buffer -> testContext.verify(() -> {
               assertThat(buffer.toString()).isEqualTo("Ok");
-              responsesReceived.flag();
+              responsesReceived.countDown();
             })));
         }
       }));

--- a/src/main/java/io/vertx/junit5/Checkpoint.java
+++ b/src/main/java/io/vertx/junit5/Checkpoint.java
@@ -16,6 +16,8 @@
 
 package io.vertx.junit5;
 
+import io.vertx.core.Completable;
+
 import java.time.Duration;
 
 /**
@@ -24,7 +26,7 @@ import java.time.Duration;
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  * @see VertxTestContext
  */
-public interface Checkpoint {
+public interface Checkpoint extends Completable<Void> {
 
   /**
    * Flags the checkpoint.

--- a/src/main/java/io/vertx/junit5/Checkpoint.java
+++ b/src/main/java/io/vertx/junit5/Checkpoint.java
@@ -19,6 +19,7 @@ package io.vertx.junit5;
 import io.vertx.core.Completable;
 
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * A test completion checkpoint, flagging it advances towards the test context completion.
@@ -32,6 +33,14 @@ public interface Checkpoint extends Completable<Void> {
    * Flags the checkpoint.
    */
   void flag();
+
+  /**
+   * Creates a new {@link CountDownLatch} that succeeds this checkpoint when the count reaches 0.
+   *
+   * @param count the latch count
+   * @return the new latch
+   */
+  CountDownLatch asLatch(int count);
 
   /**
    * Calls {@link #await(Duration)} with a timeout of 2O seconds.

--- a/src/main/java/io/vertx/junit5/CheckpointParameterProvider.java
+++ b/src/main/java/io/vertx/junit5/CheckpointParameterProvider.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.extension.ParameterContext;
  *
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
-public class VertxTestContextParameterProvider implements VertxExtensionParameterProvider<VertxTestContext> {
+public class CheckpointParameterProvider implements VertxExtensionParameterProvider<Checkpoint> {
 
   @Override
-  public Class<VertxTestContext> type() {
-    return VertxTestContext.class;
+  public Class<Checkpoint> type() {
+    return Checkpoint.class;
   }
 
   @Override
@@ -41,18 +41,18 @@ public class VertxTestContextParameterProvider implements VertxExtensionParamete
   }
 
   @Override
-  public VertxTestContext newInstance(ExtensionContext extensionContext, ParameterContext parameterContext) {
+  public Checkpoint newInstance(ExtensionContext extensionContext, ParameterContext parameterContext) {
     doNotCallMe();
     return null;
   }
 
   @Override
-  public ParameterClosingConsumer<VertxTestContext> parameterClosingConsumer() {
+  public ParameterClosingConsumer<Checkpoint> parameterClosingConsumer() {
     doNotCallMe();
     return null;
   }
 
-  private ParameterClosingConsumer<VertxTestContext> doNotCallMe() {
-    throw new UnsupportedOperationException("VertxTestContext is a built-in special case");
+  private ParameterClosingConsumer<Checkpoint> doNotCallMe() {
+    throw new UnsupportedOperationException("Checkpoint is a built-in special case");
   }
 }

--- a/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -29,14 +29,19 @@ import java.util.function.Consumer;
  */
 public final class CountingCheckpoint implements Checkpoint {
 
+  private enum Status {
+    OPEN,
+    SATISFIED,
+    CANCELLED
+  }
+
   private final Consumer<Checkpoint> satisfactionTrigger;
   private final Consumer<Throwable> overuseTrigger;
   private final int requiredNumberOfPasses;
   private final StackTraceElement creationCallSite;
 
   private int numberOfPasses = 0;
-  private boolean satisfied = false;
-  private boolean cancelled = false;
+  private Status status;
 
   public static CountingCheckpoint laxCountingCheckpoint(Consumer<Checkpoint> satisfactionTrigger, int requiredNumberOfPasses) {
     return new CountingCheckpoint(satisfactionTrigger, null, requiredNumberOfPasses);
@@ -56,14 +61,15 @@ public final class CountingCheckpoint implements Checkpoint {
     this.satisfactionTrigger = satisfactionTrigger;
     this.overuseTrigger = overuseTrigger;
     this.requiredNumberOfPasses = requiredNumberOfPasses;
+    this.status = Status.OPEN;
   }
 
   void cancel() {
     synchronized (this) {
-      if (satisfied || cancelled) {
+      if (status != Status.OPEN) {
         return;
       }
-      cancelled = true;
+      status = Status.CANCELLED;
       notifyAll();
     }
   }
@@ -83,15 +89,20 @@ public final class CountingCheckpoint implements Checkpoint {
     boolean callSatisfactionTrigger = false;
     boolean callOveruseTrigger = false;
     synchronized (this) {
-      if (satisfied) {
-        callOveruseTrigger = true;
-      } else {
-        numberOfPasses = numberOfPasses + 1;
-        if (numberOfPasses == requiredNumberOfPasses) {
-          callSatisfactionTrigger = true;
-          satisfied = true;
-          notifyAll();
-        }
+      switch (status) {
+        case OPEN:
+          numberOfPasses = numberOfPasses + 1;
+          if (numberOfPasses == requiredNumberOfPasses) {
+            callSatisfactionTrigger = true;
+            status = Status.SATISFIED;
+            notifyAll();
+          }
+          break;
+        case SATISFIED:
+          callOveruseTrigger = true;
+          break;
+        default:
+          return;
       }
     }
     if (callSatisfactionTrigger) {
@@ -107,25 +118,25 @@ public final class CountingCheckpoint implements Checkpoint {
       throw new IllegalArgumentException("Invalid timeout");
     }
     synchronized (this) {
-      if (!satisfied && !cancelled) {
+      if (status == Status.OPEN) {
         try {
           wait(timeout.toMillis());
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           throwEx(e);
         }
-        if (cancelled) {
+        if (status == Status.CANCELLED) {
           throwEx(new CancellationException("Test failed"));
         }
-        if (!satisfied) {
+        if (status != Status.SATISFIED) {
           throwEx(new TimeoutException());
         }
       }
     }
   }
 
-  public boolean satisfied() {
-    return this.satisfied;
+  public synchronized boolean satisfied() {
+    return status == Status.SATISFIED;
   }
 
   public StackTraceElement creationCallSite() {

--- a/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -19,6 +19,7 @@ package io.vertx.junit5;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -101,6 +102,11 @@ public final class CountingCheckpoint implements Checkpoint {
       }
     }
     return stackTrace[1]; // This can only happen from direct usage of CountingCheckpoint in tests, so the value is irrelevant
+  }
+
+  @Override
+  public CountDownLatch asLatch(int count) {
+    return new Latch(this, count);
   }
 
   @Override

--- a/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -29,13 +30,23 @@ import java.util.function.Consumer;
  */
 public final class CountingCheckpoint implements Checkpoint {
 
+  private static BiConsumer<Checkpoint, Throwable> wrap(Consumer<Checkpoint> consumer) {
+    Objects.requireNonNull(consumer);
+    return (source, err) -> {
+      if (err == null) {
+        consumer.accept(source);
+      }
+    };
+  }
+
   private enum Status {
     OPEN,
     SATISFIED,
+    FAILED,
     CANCELLED
   }
 
-  private final Consumer<Checkpoint> satisfactionTrigger;
+  private final BiConsumer<Checkpoint, Throwable> satisfactionTrigger;
   private final Consumer<Throwable> overuseTrigger;
   private final int requiredNumberOfPasses;
   private final StackTraceElement creationCallSite;
@@ -44,21 +55,29 @@ public final class CountingCheckpoint implements Checkpoint {
   private Status status;
 
   public static CountingCheckpoint laxCountingCheckpoint(Consumer<Checkpoint> satisfactionTrigger, int requiredNumberOfPasses) {
-    return new CountingCheckpoint(satisfactionTrigger, null, requiredNumberOfPasses);
+    return laxCountingCheckpoint(wrap(satisfactionTrigger), requiredNumberOfPasses);
   }
 
   public static CountingCheckpoint strictCountingCheckpoint(Consumer<Checkpoint> satisfactionTrigger, Consumer<Throwable> overuseTrigger, int requiredNumberOfPasses) {
     Objects.requireNonNull(overuseTrigger);
+    return strictCountingCheckpoint(wrap(satisfactionTrigger), overuseTrigger, requiredNumberOfPasses);
+  }
+
+  public static CountingCheckpoint laxCountingCheckpoint(BiConsumer<Checkpoint, Throwable> satisfactionTrigger, int requiredNumberOfPasses) {
+    return new CountingCheckpoint(satisfactionTrigger, null, requiredNumberOfPasses);
+  }
+
+  public static CountingCheckpoint strictCountingCheckpoint(BiConsumer<Checkpoint, Throwable> satisfactionTrigger, Consumer<Throwable> overuseTrigger, int requiredNumberOfPasses) {
+    Objects.requireNonNull(overuseTrigger);
     return new CountingCheckpoint(satisfactionTrigger, overuseTrigger, requiredNumberOfPasses);
   }
 
-  private CountingCheckpoint(Consumer<Checkpoint> satisfactionTrigger, Consumer<Throwable> overuseTrigger, int requiredNumberOfPasses) {
-    Objects.requireNonNull(satisfactionTrigger);
+  private CountingCheckpoint(BiConsumer<Checkpoint, Throwable> completionTrigger, Consumer<Throwable> overuseTrigger, int requiredNumberOfPasses) {
     if (requiredNumberOfPasses <= 0) {
       throw new IllegalArgumentException("A checkpoint needs at least 1 pass");
     }
     this.creationCallSite = findCallSite();
-    this.satisfactionTrigger = satisfactionTrigger;
+    this.satisfactionTrigger = completionTrigger;
     this.overuseTrigger = overuseTrigger;
     this.requiredNumberOfPasses = requiredNumberOfPasses;
     this.status = Status.OPEN;
@@ -85,6 +104,22 @@ public final class CountingCheckpoint implements Checkpoint {
   }
 
   @Override
+  public void complete(Void result, Throwable failure) {
+    if (failure != null) {
+      synchronized (this) {
+        if (status != Status.OPEN) {
+          return;
+        }
+        status = Status.FAILED;
+        notifyAll();
+      }
+      satisfactionTrigger.accept(this, failure);
+    } else {
+      flag();
+    }
+  }
+
+  @Override
   public void flag() {
     boolean callSatisfactionTrigger = false;
     boolean callOveruseTrigger = false;
@@ -106,7 +141,7 @@ public final class CountingCheckpoint implements Checkpoint {
       }
     }
     if (callSatisfactionTrigger) {
-      satisfactionTrigger.accept(this);
+      satisfactionTrigger.accept(this, null);
     } else if (callOveruseTrigger && overuseTrigger != null) {
       overuseTrigger.accept(new IllegalStateException("Strict checkpoint flagged too many times"));
     }
@@ -127,6 +162,9 @@ public final class CountingCheckpoint implements Checkpoint {
         }
         if (status == Status.CANCELLED) {
           throwEx(new CancellationException("Test failed"));
+        }
+        if (status == Status.FAILED) {
+          throwEx(new Exception("Checkpoint failed"));
         }
         if (status != Status.SATISFIED) {
           throwEx(new TimeoutException());

--- a/src/main/java/io/vertx/junit5/Latch.java
+++ b/src/main/java/io/vertx/junit5/Latch.java
@@ -1,0 +1,28 @@
+package io.vertx.junit5;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A latch counting toward checkpoint completion.
+ */
+class Latch extends CountDownLatch {
+
+  private final Checkpoint checkpoint;
+
+  Latch(Checkpoint checkpoint, int count) {
+    super(count);
+
+    this.checkpoint = checkpoint;
+  }
+
+  @Override
+  public void countDown() {
+    synchronized (this) {
+      super.countDown();
+      if (getCount() > 0) {
+        return;
+      }
+    }
+    checkpoint.succeed();
+  }
+}

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -63,22 +63,6 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
 
   private static final String TEST_CONFIG = "TestConfig";
 
-  private static class VertxTestContextEntry {
-    private final VertxTestContext context;
-    private final Checkpoint checkpoint;
-    public VertxTestContextEntry(VertxTestContext context, Checkpoint checkpoint) {
-      this.context = context;
-      this.checkpoint = checkpoint;
-    }
-  }
-
-  private static class ContextList extends ArrayList<VertxTestContextEntry> {
-    /*
-     * There may be concurrent test contexts to join at a point of time because it is allowed to have several
-     * user-defined lifecycle event handles (e.g., @BeforeEach, etc).
-     */
-  }
-
   private final HashMap<Class<?>, VertxExtensionParameterProvider<?>> parameterProviders = new HashMap<>();
 
   public VertxExtension() {
@@ -101,7 +85,6 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
    * Hold context data for the test
    */
   private static class TestConfig {
-    private List<VertxTestContextEntry> testContexts;
     private boolean instrumentVertx;
   }
 
@@ -136,7 +119,9 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
     VertxExtensionParameterProvider<?> parameterProvider = parameterProviders.get(type);
 
     if (type.equals(VertxTestContext.class)) {
-      return newTestContext(extensionContext);
+      VertxTestContext ctx = testContext(extensionContext);
+      ctx.numberOfInjections++;
+      return ctx;
     }
 
     if (extensionContext.getParent().isPresent()) {
@@ -163,25 +148,9 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
     Store store = extensionContext.getStore(Namespace.GLOBAL);
     ScopedObject<Vertx> scopedVertx = (ScopedObject<Vertx>)store.get(VERTX_INSTANCE_KEY);
     if (instrumentVertx(extensionContext) && scopedVertx != null) {
-      ContextList entries = (ContextList)store.get(TEST_CONTEXT_KEY);
-      if (entries == null) {
-        // Create an implicit test context that is never a parameter but required to report test failures
-        VertxTestContext context = newTestContext(extensionContext);
-        // Fake checkpoint required to switch the test context to checkpoint mode to get the test completed
-        context.checkpoint().flag();
-        entries = (ContextList)store.get(TEST_CONTEXT_KEY);
-      }
-      List<VertxTestContext> testContexts = entries
-        .stream()
-        .map(entry -> entry.context)
-        .collect(Collectors.toList());
+      VertxTestContext ctx = testContext(extensionContext);
       Vertx vertx = scopedVertx.get();
-      vertx.exceptionHandler(failure -> {
-        for (VertxTestContext context : testContexts) {
-          context.failNow(failure);
-          break;
-        }
-      });
+      vertx.exceptionHandler(ctx::failNow);
     }
   }
 
@@ -194,13 +163,13 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
     }
   }
 
-  private VertxTestContext newTestContext(ExtensionContext extensionContext) {
+  private VertxTestContext testContext(ExtensionContext extensionContext) {
     Store store = store(extensionContext);
-    ContextList contexts = (ContextList) store.getOrComputeIfAbsent(TEST_CONTEXT_KEY, key -> new ContextList());
-    VertxTestContext newTestContext = new VertxTestContext();
-    Checkpoint invocationCheckpoint = newTestContext.checkpoint();
-    contexts.add(new VertxTestContextEntry(newTestContext, invocationCheckpoint));
-    return newTestContext;
+    return (VertxTestContext) store.getOrComputeIfAbsent(TEST_CONTEXT_KEY, key -> {
+      VertxTestContext ctx = new VertxTestContext();
+      ctx.invocationCheckpoint = ctx.checkpoint();
+      return ctx;
+    });
   }
 
   private static Store store(ExtensionContext extensionContext) {
@@ -295,56 +264,56 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
       }
     }
 
-    ContextList current = store(extensionContext).remove(TEST_CONTEXT_KEY, ContextList.class);
-    if (current != null) {
-      for (VertxTestContextEntry entry : current) {
-        VertxTestContext context = entry.context;
-        // Check if the invocation checkpoint is the only one if that is the case
-        // then the method passing relies on completeNow to validate the test
-        if (context.numberOfCheckpoints() != 1) {
-          // Flag invocation checkpoint
-          entry.checkpoint.flag();
-        }
-        int timeoutDuration = DEFAULT_TIMEOUT_DURATION;
-        TimeUnit timeoutUnit = DEFAULT_TIMEOUT_UNIT;
-        Optional<Method> testMethod = extensionContext.getTestMethod();
-        if (testMethod.isPresent() && testMethod.get().isAnnotationPresent(Timeout.class)) {
-          Timeout annotation = extensionContext.getRequiredTestMethod().getAnnotation(Timeout.class);
-          timeoutDuration = annotation.value();
-          timeoutUnit = annotation.timeUnit();
-        } else {
-          for (
-            Class<?> testClass = extensionContext.getRequiredTestClass();
-            testClass != null;
-            testClass = testClass.isAnnotationPresent(Nested.class) ? testClass.getEnclosingClass() : null
-          ) {
-            if (testClass.isAnnotationPresent(Timeout.class)) {
-              Timeout annotation = testClass.getAnnotation(Timeout.class);
-              timeoutDuration = annotation.value();
-              timeoutUnit = annotation.timeUnit();
-              break;
-            }
+    VertxTestContext context = store(extensionContext).remove(TEST_CONTEXT_KEY, VertxTestContext.class);
+    if (context != null) {
+
+      // Check if the invocation checkpoint is the only one if that is the case
+      // then the method passing relies on completeNow to validate the test
+      if (context.numberOfInjections == 0 || context.numberOfCheckpoints() != 1) {
+        // Flag invocation checkpoint
+        context.invocationCheckpoint.flag();
+      }
+
+
+      int timeoutDuration = DEFAULT_TIMEOUT_DURATION;
+      TimeUnit timeoutUnit = DEFAULT_TIMEOUT_UNIT;
+      Optional<Method> testMethod = extensionContext.getTestMethod();
+      if (testMethod.isPresent() && testMethod.get().isAnnotationPresent(Timeout.class)) {
+        Timeout annotation = extensionContext.getRequiredTestMethod().getAnnotation(Timeout.class);
+        timeoutDuration = annotation.value();
+        timeoutUnit = annotation.timeUnit();
+      } else {
+        for (
+          Class<?> testClass = extensionContext.getRequiredTestClass();
+          testClass != null;
+          testClass = testClass.isAnnotationPresent(Nested.class) ? testClass.getEnclosingClass() : null
+        ) {
+          if (testClass.isAnnotationPresent(Timeout.class)) {
+            Timeout annotation = testClass.getAnnotation(Timeout.class);
+            timeoutDuration = annotation.value();
+            timeoutUnit = annotation.timeUnit();
+            break;
           }
         }
-        if (context.awaitCompletion(timeoutDuration, timeoutUnit)) {
-          if (context.failed()) {
-            Throwable throwable = context.causeOfFailure();
-            if (throwable instanceof Exception) {
-              throw (Exception) throwable;
-            } else {
-              throw new AssertionError(throwable);
-            }
+      }
+      if (context.awaitCompletion(timeoutDuration, timeoutUnit)) {
+        if (context.failed()) {
+          Throwable throwable = context.causeOfFailure();
+          if (throwable instanceof Exception) {
+            throw (Exception) throwable;
+          } else {
+            throw new AssertionError(throwable);
           }
-        } else {
-          String message = "The test execution timed out. Make sure your asynchronous code "
-            + "includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() "
-            + "or Checkpoint#flag()";
-          message = message +  context.unsatisfiedCheckpointCallSites()
-            .stream()
-            .map(element -> String.format("-> checkpoint at %s", element))
-            .collect(Collectors.joining("\n", "\n\nUnsatisfied checkpoints diagnostics:\n", ""));
-          throw new TimeoutException(message);
         }
+      } else {
+        String message = "The test execution timed out. Make sure your asynchronous code "
+          + "includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() "
+          + "or Checkpoint#flag()";
+        message = message +  context.unsatisfiedCheckpointCallSites()
+          .stream()
+          .map(element -> String.format("-> checkpoint at %s", element))
+          .collect(Collectors.joining("\n", "\n\nUnsatisfied checkpoints diagnostics:\n", ""));
+        throw new TimeoutException(message);
       }
     }
 

--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -124,6 +124,11 @@ public final class VertxExtension implements ParameterResolver, InvocationInterc
       return ctx;
     }
 
+    if (type.equals(Checkpoint.class)) {
+      VertxTestContext ctx = testContext(extensionContext);
+      return ctx.checkpoint();
+    }
+
     if (extensionContext.getParent().isPresent()) {
       Store parentStore = store(extensionContext.getParent().get());
       if (parentStore.get(parameterProvider.key()) != null) {

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -45,6 +45,9 @@ public final class VertxTestContext {
 
   // ........................................................................................... //
 
+  int numberOfInjections;
+  Checkpoint invocationCheckpoint;
+
   private Throwable throwableReference = null;
   private boolean done = false;
   private final CountDownLatch releaseLatch = new CountDownLatch(1);

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -143,6 +143,14 @@ public final class VertxTestContext {
 
   // ........................................................................................... //
 
+  private void checkpointCompleted(Checkpoint checkpoint, Throwable failure) {
+    if (failure != null) {
+      failNow(failure);
+    } else {
+      checkpointSatisfied(checkpoint);
+    }
+  }
+
   private synchronized void checkpointSatisfied(Checkpoint checkpoint) {
     checkpoints.remove(checkpoint);
     if (checkpoints.isEmpty()) {
@@ -169,7 +177,7 @@ public final class VertxTestContext {
     if (done) {
       throw new IllegalStateException("Context has already been completed");
     }
-    CountingCheckpoint checkpoint = CountingCheckpoint.laxCountingCheckpoint(this::checkpointSatisfied, requiredNumberOfPasses);
+    CountingCheckpoint checkpoint = CountingCheckpoint.laxCountingCheckpoint(this::checkpointCompleted, requiredNumberOfPasses);
     checkpoints.add(checkpoint);
     numberOfCheckpoints++;
     return checkpoint;
@@ -194,7 +202,7 @@ public final class VertxTestContext {
     if (done) {
       throw new IllegalStateException("Context has already been completed");
     }
-    CountingCheckpoint checkpoint = CountingCheckpoint.strictCountingCheckpoint(this::checkpointSatisfied, this::failNow, requiredNumberOfPasses);
+    CountingCheckpoint checkpoint = CountingCheckpoint.strictCountingCheckpoint(this::checkpointCompleted, this::failNow, requiredNumberOfPasses);
     checkpoints.add(checkpoint);
     numberOfCheckpoints++;
     return checkpoint;

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -175,7 +175,9 @@ public final class VertxTestContext {
    *
    * @param requiredNumberOfPasses the required number of passes to validate the checkpoint.
    * @return a checkpoint that requires several passes; more passes than the required number are allowed and ignored.
+   * @deprecated instead create a regular checkpoint and use {@link Checkpoint#asLatch(int)} to create a latch succeeding this checkpoint
    */
+  @Deprecated
   public synchronized Checkpoint laxCheckpoint(int requiredNumberOfPasses) {
     if (done) {
       throw new IllegalStateException("Context has already been completed");
@@ -200,7 +202,9 @@ public final class VertxTestContext {
    *
    * @param requiredNumberOfPasses the required number of passes to validate the checkpoint.
    * @return a checkpoint that requires several passes, but no more, or it fails the context.
+   * @deprecated instead create a regular checkpoint and use {@link Checkpoint#asLatch(int)} to create a latch succeeding this checkpoint
    */
+  @Deprecated
   public synchronized Checkpoint checkpoint(int requiredNumberOfPasses) {
     if (done) {
       throw new IllegalStateException("Context has already been completed");

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -16,6 +16,9 @@ module io.vertx.testing.junit5 {
   uses io.vertx.junit5.VertxExtensionParameterProvider;
 
   provides ParameterResolver with io.vertx.junit5.VertxExtension;
-  provides io.vertx.junit5.VertxExtensionParameterProvider with io.vertx.junit5.VertxParameterProvider, io.vertx.junit5.VertxTestContextParameterProvider;
+  provides io.vertx.junit5.VertxExtensionParameterProvider with
+    io.vertx.junit5.VertxParameterProvider,
+    io.vertx.junit5.VertxTestContextParameterProvider,
+    io.vertx.junit5.CheckpointParameterProvider;
 
 }

--- a/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
+++ b/src/main/resources/META-INF/services/io.vertx.junit5.VertxExtensionParameterProvider
@@ -1,2 +1,3 @@
 io.vertx.junit5.VertxParameterProvider
 io.vertx.junit5.VertxTestContextParameterProvider
+io.vertx.junit5.CheckpointParameterProvider

--- a/src/test/java/io/vertx/junit5/tests/CheckpointInjectionTest.java
+++ b/src/test/java/io/vertx/junit5/tests/CheckpointInjectionTest.java
@@ -1,0 +1,89 @@
+package io.vertx.junit5.tests;
+
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CheckpointInjectionTest {
+
+  @VertxTest
+  public static class InjectCheckpointsInSameMethod {
+
+    private static Checkpoint checkpoint1, checkpoint2;
+
+    @Test
+    public void test(Checkpoint checkpoint1, Checkpoint checkpoint2) {
+      InjectCheckpointsInSameMethod.checkpoint1 = checkpoint1;
+      InjectCheckpointsInSameMethod.checkpoint2 = checkpoint2;
+      doAsync(100, () -> {
+        checkpoint1.flag();
+        checkpoint2.flag();
+      });
+    }
+  }
+
+  @Test
+  void testInjectCheckpointsInSameMethod() {
+    try {
+      TestExecutionSummary summary = VertxParameterProviderLifeCycleTest.runTests(InjectCheckpointsInSameMethod.class);
+      assertEquals(1, summary.getTestsSucceededCount());
+      assertNotNull(InjectCheckpointsInSameMethod.checkpoint1);
+      assertNotNull(InjectCheckpointsInSameMethod.checkpoint2);
+      assertNotSame(InjectCheckpointsInSameMethod.checkpoint1, InjectCheckpointsInSameMethod.checkpoint2);
+    } finally {
+      InjectCheckpointsInSameMethod.checkpoint1 = null;
+      InjectCheckpointsInSameMethod.checkpoint2 = null;
+    }
+  }
+
+  @Test
+  void testInjectDifferentCheckpointsInLifecycle() {
+    try {
+      TestExecutionSummary summary = VertxParameterProviderLifeCycleTest.runTests(InjectDifferentCheckpointsInLifecycle.class);
+      assertEquals(1, summary.getTestsSucceededCount());
+      assertNotNull(InjectDifferentCheckpointsInLifecycle.checkpoint1);
+      assertNotNull(InjectDifferentCheckpointsInLifecycle.checkpoint2);
+      assertNotSame(InjectDifferentCheckpointsInLifecycle.checkpoint1, InjectCheckpointsInSameMethod.checkpoint2);
+    } finally {
+      InjectDifferentCheckpointsInLifecycle.checkpoint1 = null;
+      InjectDifferentCheckpointsInLifecycle.checkpoint2 = null;
+    }
+  }
+
+  @VertxTest
+  public static class InjectDifferentCheckpointsInLifecycle {
+
+    private static Checkpoint checkpoint1, checkpoint2;
+
+    @BeforeEach
+    public void before(Checkpoint checkpoint1) {
+      InjectDifferentCheckpointsInLifecycle.checkpoint1 = checkpoint1;
+      doAsync(100, () -> {
+        checkpoint1.flag();
+      });
+    }
+
+    @Test
+    public void test(Checkpoint checkpoint2) {
+      InjectDifferentCheckpointsInLifecycle.checkpoint2 = checkpoint2;
+      doAsync(100, () -> {
+        checkpoint2.flag();
+      });
+    }
+  }
+
+  private static void doAsync(long delay, Runnable runnable) {
+    new Thread(() -> {
+      try {
+        Thread.sleep(delay);
+      } catch (InterruptedException ignore) {
+      }
+      runnable.run();
+    }).start();
+  }
+
+}

--- a/src/test/java/io/vertx/junit5/tests/CountingCheckpointTest.java
+++ b/src/test/java/io/vertx/junit5/tests/CountingCheckpointTest.java
@@ -67,7 +67,7 @@ class CountingCheckpointTest {
   @Test
   @DisplayName("Refuse null triggers")
   void refuse_null_triggers() {
-    assertThrows(NullPointerException.class, () -> CountingCheckpoint.laxCountingCheckpoint(null, 1));
+    assertThrows(NullPointerException.class, () -> CountingCheckpoint.laxCountingCheckpoint((Consumer<Checkpoint>)null, 1));
     assertThrows(NullPointerException.class, () -> CountingCheckpoint.strictCountingCheckpoint(v -> {
     }, null, 1));
   }

--- a/src/test/java/io/vertx/junit5/tests/VertxExtensionTest.java
+++ b/src/test/java/io/vertx/junit5/tests/VertxExtensionTest.java
@@ -78,10 +78,9 @@ class VertxExtensionTest {
 
     @Test
     @DisplayName("Inject 2 VertxTestContext instances and check they are different")
-    void gimme_2_vertx(VertxTestContext context1, VertxTestContext context2) {
-      assertNotSame(context1, context2);
+    void gimme_2_vertx_contexts(VertxTestContext context1, VertxTestContext context2) {
+      assertSame(context1, context2);
       context1.completeNow();
-      context2.completeNow();
     }
   }
 
@@ -259,7 +258,7 @@ class VertxExtensionTest {
 
       @Test
       @Tag("programmatic")
-      void flagTooMuch(VertxTestContext testContext) {
+      void theTest(VertxTestContext testContext) {
         Checkpoint checkpoint1 = testContext.checkpoint();
         checkpoint1.flag();
         Checkpoint checkpoint2 = testContext.checkpoint();

--- a/src/test/java/io/vertx/junit5/tests/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/tests/VertxTestContextTest.java
@@ -513,4 +513,35 @@ class VertxTestContextTest {
       assertSame(TimeoutException.class, e.getClass());
     }
   }
+
+  @Test
+  @DisplayName("Check failing a checkpoint")
+  void check_checkpoint_fail() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+
+    Exception failure = new Exception();
+
+    Checkpoint a = context.checkpoint();
+    a.fail(failure);
+
+    assertThat(context.awaitCompletion(500, TimeUnit.MILLISECONDS)).isTrue();
+    assertThat(context.failed()).isTrue();
+    assertThat(context.causeOfFailure())
+      .isSameAs(failure);
+  }
+
+  @Test
+  @DisplayName("Check failing a checkpoint after it succeeded")
+  void check_checkpoint_fail_after_success() throws InterruptedException {
+    VertxTestContext context = new VertxTestContext();
+
+    Exception failure = new Exception();
+
+    Checkpoint a = context.checkpoint();
+    a.flag();
+    a.fail(failure);
+
+    assertThat(context.awaitCompletion(500, TimeUnit.MILLISECONDS)).isTrue();
+    assertThat(context.failed()).isFalse();
+  }
 }


### PR DESCRIPTION
A few features:

- `Checkpoint` extends now `Completable`: they can be failed and used as listener on futures
- Create a single `VertxTestContext` per invocation
- Support `Checkpoint` injection, from now on this should be the default API to interact with checkpoints
- Provide a latching view of a checkpoint, from now on this should be preferred over counting checkpoints