### PR TITLE
docs: document assertComplete and assertFailure for Future-based tests

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -80,9 +80,36 @@ The useful methods in {@link io.vertx.junit5.VertxTestContext} are the following
 * {@link io.vertx.junit5.VertxTestContext#succeeding} to provide `Handler<AsyncResult<T>>` handlers that expect a success and pass the result to another callback, any exception thrown from the callback is considered as a test failure
 * {@link io.vertx.junit5.VertxTestContext#failing} to provide `Handler<AsyncResult<T>>` handlers that expect a failure and pass the exception to another callback, any exception thrown from the callback is considered as a test failure
 * {@link io.vertx.junit5.VertxTestContext#verify} to perform assertions, any exception thrown from the code block is considered as a test failure.
+* {@link io.vertx.junit5.VertxTestContext#assertComplete} to assert that a `Future` succeeds within a composition chain
+* {@link io.vertx.junit5.VertxTestContext#assertFailure} to assert that a `Future` fails within a composition chain
 
 WARNING: Unlike `succeedingThenComplete` and `failingThenComplete`, calling `succeeding` and `failing` methods can only make a test fail (e.g., `succeeding` gets a failed asynchronous result).
 To make a test pass you still need to call `completeNow`, or use checkpoints as explained below.
+
+== Testing with Future chains
+
+When writing `Future`-based tests, you can compose asynchronous steps and use {@link io.vertx.junit5.VertxTestContext#assertComplete} and {@link io.vertx.junit5.VertxTestContext#assertFailure} to validate intermediate outcomes.
+On the unexpected outcome these helpers fail the test context (`failNow`); they do not complete the test by themselves — still call `completeNow` (or use an explicit checkpoint), as in the examples below.
+
+To assert that a `Future` completes successfully:
+
+[source,java]
+----
+{@link examples.Examples#usingAssertComplete}
+----
+
+<1> {@link io.vertx.junit5.VertxTestContext#assertComplete} returns a `Future` that completes with the same result when the input future succeeds, or fails the test context when the input future fails.
+
+To assert that a `Future` fails as expected:
+
+[source,java]
+----
+{@link examples.Examples#usingAssertFailure}
+----
+
+<1> {@link io.vertx.junit5.VertxTestContext#assertFailure} returns a `Future` that fails with the original cause when the input future fails, or fails the test context when the input future succeeds.
+
+These methods can be chained with {@link io.vertx.core.Future#compose} and {@link io.vertx.core.Future#recover} to express multi-step asynchronous tests with fewer callback-style assertions.
 
 == Checkpoint when there are multiple success conditions
 

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -16,6 +16,7 @@
 
 package examples;
 
+import io.vertx.core.Future;
 import io.vertx.core.VerticleBase;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
@@ -112,6 +113,32 @@ public class Examples {
       .compose(req -> req.send().compose(HttpClientResponse::body))
       .onComplete(testContext.succeeding(buffer -> testContext.verify(() -> {
         assertThat(buffer.toString()).isEqualTo("Plop");
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  public void usingAssertComplete(Vertx vertx, VertxTestContext testContext) {
+    client = vertx.createHttpClient();
+
+    testContext
+      .assertComplete(client.request(HttpMethod.GET, 8080, "localhost", "/") // <1>
+        .compose(req -> req.send())
+        .compose(HttpClientResponse::body))
+      .onComplete(testContext.succeeding(buffer -> testContext.verify(() -> {
+        assertThat(buffer.toString()).isEqualTo("Plop");
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  public void usingAssertFailure(Vertx vertx, VertxTestContext testContext) {
+    testContext
+      .assertFailure(Future.failedFuture(new IllegalStateException("expected failure"))) // <1>
+      .onComplete(testContext.failing(ex -> testContext.verify(() -> {
+        assertThat(ex)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("expected failure");
         testContext.completeNow();
       })));
   }


### PR DESCRIPTION
## Summary

- Document `VertxTestContext#assertComplete` and `#assertFailure` in the module manual (`index.adoc`).
- Add runnable examples (`usingAssertComplete`, `usingAssertFailure`) included via docgen, matching existing style.
- Explain how these Future-chain helpers fit the Vert.x 5 move away from callback-based `Handler<AsyncResult<T>>` testing.

Fixes #140

## Test plan

- [x] Examples follow the same patterns as existing `Examples` tests and unit tests in `VertxTestContextTest`.
- [x] AsciiDoc section uses `{@link examples.Examples#...}` includes and callout markers consistent with neighboring sections.
- [ ] CI docgen/build (maintainer merge path).

## Contributor note

Eclipse Contributor Agreement (ECA) will be signed by the human contributor before merge.


Made with [Cursor](https://cursor.com)